### PR TITLE
[bot] Fix Rails/SaveBang

### DIFF
--- a/src/cop/rails/save_bang.rs
+++ b/src/cop/rails/save_bang.rs
@@ -403,6 +403,26 @@ use ruby_prism::Visit;
 /// per variable. A variable is only added to `suppressed_create_vars` if ALL of its
 /// create assignments have a persisted? check before the next create assignment to that
 /// variable (or end of scope).
+///
+/// ## Corpus investigation (2026-03-26)
+///
+/// Prompted corpus FN batch: 0 FP, 22 FN.
+///
+/// Added fixture coverage for the reported shapes:
+/// - `klass.methods_hash.update mod.methods_hash` and related no-paren `update` calls
+///   inside multi-statement method bodies
+/// - bare `update` calls inside multi-statement method bodies
+/// - nested-block / multiline `create` calls from vendored Puppet code
+///
+/// Those fixtures pass without logic changes, and direct per-file nitrocop runs against the
+/// cloned corpus files also report the expected offenses at the exact oracle lines
+/// (RDoc class_module.rb, TMail mailbox.rb, Puppet util.rb / metric.rb).
+///
+/// However, `python3 scripts/check_cop.py Rails/SaveBang --rerun --clone --sample 15`
+/// still reports the same 22 FN when it runs whole repos. That points away from
+/// `Rails/SaveBang` detection and toward repo-level file discovery or selection for
+/// vendored paths during corpus reruns. Keep cop logic unchanged unless a future
+/// investigation proves a direct per-file miss.
 pub struct SaveBang;
 
 /// Modify-type persistence methods whose return value indicates success/failure.

--- a/tests/fixtures/cops/rails/save_bang/offense.rb
+++ b/tests/fixtures/cops/rails/save_bang/offense.rb
@@ -300,3 +300,84 @@ def metafield_example
                                        ^^^^^^ Rails/SaveBang: Use `create!` instead of `create` if the return value is not checked. Or check `persisted?` on model returned from `create`.
   nil
 end
+
+# RDoc merge helpers: modify calls in multi-statement method bodies should still be flagged
+def merge(mod, klass)
+  klass.attributes.concat mod.attributes
+  klass.method_list.concat mod.method_list
+  klass.aliases.concat mod.aliases
+  klass.external_aliases.concat mod.external_aliases
+  klass.constants.concat mod.constants
+  klass.includes.concat mod.includes
+
+  klass.methods_hash.update mod.methods_hash
+                     ^^^^^^ Rails/SaveBang: Use `update!` instead of `update` if the return value is not checked.
+  klass.constants_hash.update mod.constants_hash
+                       ^^^^^^ Rails/SaveBang: Use `update!` instead of `update` if the return value is not checked.
+
+  klass.current_section = mod.current_section
+  klass.in_files.concat mod.in_files
+  klass.sections.concat mod.sections
+  klass.unmatched_alias_lists = mod.unmatched_alias_lists
+  klass.current_section = mod.current_section
+  klass.visibility = mod.visibility
+
+  klass.classes_hash.update mod.classes_hash
+                     ^^^^^^ Rails/SaveBang: Use `update!` instead of `update` if the return value is not checked.
+  klass.modules_hash.update mod.modules_hash
+                     ^^^^^^ Rails/SaveBang: Use `update!` instead of `update` if the return value is not checked.
+  klass.metadata.update mod.metadata
+                 ^^^^^^ Rails/SaveBang: Use `update!` instead of `update` if the return value is not checked.
+
+  klass.document_self = mod.received_nodoc ? nil : mod.document_self
+  klass.document_children = mod.document_children
+  klass.force_documentation = mod.force_documentation
+  klass.done_documenting = mod.done_documenting
+end
+
+# Bare update in a multi-statement method body is void context
+def each_port(&block)
+  close_check
+  update
+  ^^^^^^ Rails/SaveBang: Use `update!` instead of `update` if the return value is not checked.
+  @real.each_port(&block)
+end
+
+# Nested block/proc bodies do not exempt create calls
+def self.logmethods(klass, useself = true)
+  Puppet::Util::Log.eachlevel { |level|
+    klass.send(:define_method, level, proc { |args|
+      args = args.join(" ") if args.is_a?(Array)
+      if useself
+        Puppet::Util::Log.create(
+                          ^^^^^^ Rails/SaveBang: Use `create!` instead of `create` if the return value is not checked.
+          :level => level,
+          :source => self,
+          :message => args
+        )
+      else
+        Puppet::Util::Log.create(
+                          ^^^^^^ Rails/SaveBang: Use `create!` instead of `create` if the return value is not checked.
+          :level => level,
+          :message => args
+        )
+      end
+    })
+  }
+end
+
+# Create assigned to a local without persisted? should be flagged
+def execute_windows(command, arguments, stdin, stdout, stderr)
+  process_info = Process.create(
+                         ^^^^^^ Rails/SaveBang: Use `create!` instead of `create` if the return value is not checked. Or check `persisted?` on model returned from `create`.
+    :command_line => command,
+    :startup_info => {:stdin => stdin, :stdout => stdout, :stderr => stderr}
+  )
+  process_info.process_id
+end
+
+# Create in modifier-unless body is void context, not condition context
+def store(time)
+  self.create(time - 5) unless FileTest.exists?(self.path)
+       ^^^^^^ Rails/SaveBang: Use `create!` instead of `create` if the return value is not checked.
+end


### PR DESCRIPTION
Restored from agent run [#23570271888](https://github.com/6/nitrocop/actions/runs/23570271888) — the scope guard incorrectly rejected the PR due to untracked scratch files.

Agent found the 22 FN are caused by repo-level file discovery during corpus reruns, not cop detection logic. Direct per-file runs match RuboCop at the exact oracle lines.

- Doc comment documenting the root cause
- Fixture coverage for all reported FN patterns

Refs #172