### PR TITLE
Fix directive parser: strip trailing slash from department names

### DIFF
--- a/src/parse/directives.rs
+++ b/src/parse/directives.rs
@@ -22,6 +22,10 @@ static DIRECTIVE_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// department token, so the range is stored under the department key and
 /// `is_disabled` matches via the department check.
 fn normalize_directive_cop_name(name: &str) -> String {
+    // Strip trailing `/` — users write `# rubocop:disable Metrics/` to mean
+    // the department.  RuboCop treats `Metrics/` identically to `Metrics`.
+    let name = name.strip_suffix('/').unwrap_or(name);
+
     if let Some((dept, _cop)) = name.split_once("::") {
         return dept.to_string();
     }
@@ -554,6 +558,36 @@ mod tests {
         assert!(dr.is_disabled("Metrics/MethodLength", 3));
         // Line after enable is no longer disabled
         assert!(!dr.is_disabled("Metrics/MethodLength", 4));
+    }
+
+    #[test]
+    fn department_disable_trailing_slash() {
+        // `# rubocop:disable Metrics/` (with trailing slash) should work
+        // identically to `# rubocop:disable Metrics`.
+        let src = "# rubocop:disable Metrics/\nx = 1\n# rubocop:enable Metrics/\ny = 2\n";
+        let dr = disabled_ranges(src);
+        assert!(
+            dr.is_disabled("Metrics/MethodLength", 2),
+            "Metrics/ should disable Metrics/MethodLength"
+        );
+        assert!(
+            dr.is_disabled("Metrics/CyclomaticComplexity", 2),
+            "Metrics/ should disable Metrics/CyclomaticComplexity"
+        );
+        assert!(!dr.is_disabled("Layout/LineLength", 2));
+        assert!(!dr.is_disabled("Metrics/MethodLength", 4));
+    }
+
+    #[test]
+    fn department_disable_trailing_slash_inline() {
+        // Inline variant: `x = 1 # rubocop:disable Metrics/ -- reason`
+        let src = "x = 1 # rubocop:disable Metrics/ -- It's more readable this way\ny = 2\n";
+        let dr = disabled_ranges(src);
+        assert!(
+            dr.is_disabled("Metrics/PerceivedComplexity", 1),
+            "inline Metrics/ should disable Metrics cops on same line"
+        );
+        assert!(!dr.is_disabled("Metrics/PerceivedComplexity", 2));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `# rubocop:disable Metrics/` was stored as key `"Metrics/"` instead of `"Metrics"`, so `is_disabled()` couldn't match it
- RuboCop treats `Metrics/` identically to `Metrics`
- Fixes FPs in PerceivedComplexity and CyclomaticComplexity where inline `# rubocop:disable Metrics/` comments were ignored
- Root cause documented by agents investigating both cops independently

## Test plan
- [x] Added `department_disable_trailing_slash` and `department_disable_trailing_slash_inline` tests
- [x] All 58 directive tests pass
- [ ] Awaiting cop-check results for Metrics/PerceivedComplexity and Metrics/CyclomaticComplexity

🤖 Generated with [Claude Code](https://claude.com/claude-code)