### PR TITLE
Switch corpus verification to counter-based multi-offense comparison

### DIFF
--- a/bench/compare.rb
+++ b/bench/compare.rb
@@ -5,7 +5,6 @@
 # Usage: compare.rb [--json out.json] <nitrocop.json> <rubocop.json> [covered-cops.txt] [repo-dir]
 
 require "json"
-require "set"
 
 # Parse --json flag
 json_output_file = nil
@@ -22,7 +21,7 @@ end
 
 # Load covered cops list (one per line from --list-cops output)
 covered = if covered_cops_file && File.exist?(covered_cops_file)
-            File.readlines(covered_cops_file).map(&:strip).reject(&:empty?).to_set
+            Set.new(File.readlines(covered_cops_file).map(&:strip).reject(&:empty?))
           end
 
 # Path normalization: strip repo_dir prefix from nitrocop paths so both
@@ -36,15 +35,15 @@ end
 
 # Parse nitrocop JSON (flat: { offenses: [ { path, line, cop_name } ] })
 nitrocop_data = JSON.parse(File.read(nitrocop_file))
-nitrocop_offenses = Set.new
+nitrocop_counts = Hash.new(0)
 nitrocop_data["offenses"].each do |o|
   path = normalize_path(o["path"], repo_prefix)
-  nitrocop_offenses << [path, o["line"], o["cop_name"]]
+  nitrocop_counts[[path, o["line"], o["cop_name"]]] += 1
 end
 
 # Parse rubocop JSON (nested: { files: [ { path, offenses: [ { location: { start_line }, cop_name } ] } ] })
 rubocop_data = JSON.parse(File.read(rubocop_file))
-rubocop_offenses = Set.new
+rubocop_counts = Hash.new(0)
 rubocop_data["files"].each do |file_entry|
   path = file_entry["path"]
   (file_entry["offenses"] || []).each do |o|
@@ -52,32 +51,53 @@ rubocop_data["files"].each do |file_entry|
     # Filter to only cops nitrocop covers
     next if covered && !covered.include?(cop)
     line = o.dig("location", "start_line") || o.dig("location", "line")
-    rubocop_offenses << [path, line, cop]
+    rubocop_counts[[path, line, cop]] += 1
   end
 end
 
-# Compare
-false_positives = nitrocop_offenses - rubocop_offenses
-false_negatives = rubocop_offenses - nitrocop_offenses
-matches = nitrocop_offenses & rubocop_offenses
-total = (nitrocop_offenses | rubocop_offenses).size
-match_rate = total.zero? ? 100.0 : (matches.size.to_f / total * 100)
+# Compare using counter arithmetic (multiset)
+all_keys = (nitrocop_counts.keys + rubocop_counts.keys).uniq
+n_matches = 0
+n_fp = 0
+n_fn = 0
+per_cop = Hash.new { |h, k| h[k] = {fp: 0, fn: 0, match: 0} }
+
+all_keys.each do |key|
+  nc = nitrocop_counts[key]
+  rc = rubocop_counts[key]
+  matched = [nc, rc].min
+  excess = [nc - rc, 0].max
+  deficit = [rc - nc, 0].max
+  cop = key[2]
+
+  n_matches += matched
+  per_cop[cop][:match] += matched
+
+  if excess > 0
+    n_fp += excess
+    per_cop[cop][:fp] += excess
+  end
+  if deficit > 0
+    n_fn += deficit
+    per_cop[cop][:fn] += deficit
+  end
+end
+
+nitrocop_total = nitrocop_counts.values.sum
+rubocop_total = rubocop_counts.values.sum
+total = n_matches + n_fp + n_fn
+match_rate = total.zero? ? 100.0 : (n_matches.to_f / total * 100)
 
 puts "=== Conformance Report ==="
-puts "  nitrocop offenses:  #{nitrocop_offenses.size}"
-puts "  rubocop offenses: #{rubocop_offenses.size} (filtered to covered cops)"
-puts "  matches:          #{matches.size}"
-puts "  false positives:  #{false_positives.size} (nitrocop only)"
-puts "  false negatives:  #{false_negatives.size} (rubocop only)"
+puts "  nitrocop offenses:  #{nitrocop_total}"
+puts "  rubocop offenses: #{rubocop_total} (filtered to covered cops)"
+puts "  matches:          #{n_matches}"
+puts "  false positives:  #{n_fp} (nitrocop only)"
+puts "  false negatives:  #{n_fn} (rubocop only)"
 puts "  match rate:       #{"%.1f" % match_rate}%"
 puts ""
 
 # Per-cop breakdown (only cops with differences)
-per_cop = Hash.new { |h, k| h[k] = {fp: 0, fn: 0, match: 0} }
-false_positives.each { |_, _, cop| per_cop[cop][:fp] += 1 }
-false_negatives.each { |_, _, cop| per_cop[cop][:fn] += 1 }
-matches.each { |_, _, cop| per_cop[cop][:match] += 1 }
-
 divergent = per_cop.select { |_, v| v[:fp] > 0 || v[:fn] > 0 }
   .sort_by { |_, v| -(v[:fp] + v[:fn]) }
 
@@ -96,11 +116,11 @@ end
 # Write machine-readable JSON for report.rb
 if json_output_file
   report = {
-    nitrocop_count: nitrocop_offenses.size,
-    rubocop_count: rubocop_offenses.size,
-    matches: matches.size,
-    false_positives: false_positives.size,
-    false_negatives: false_negatives.size,
+    nitrocop_count: nitrocop_total,
+    rubocop_count: rubocop_total,
+    matches: n_matches,
+    false_positives: n_fp,
+    false_negatives: n_fn,
     match_rate: match_rate.round(1),
     per_cop: per_cop.transform_values { |v| {match: v[:match], fp: v[:fp], fn: v[:fn]} }
   }

--- a/bench/corpus/diff_results.py
+++ b/bench/corpus/diff_results.py
@@ -16,7 +16,7 @@ import argparse
 import json
 import math
 import sys
-from collections import defaultdict
+from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -84,7 +84,7 @@ def read_err_snippet(json_path: Path, tool: str) -> str:
     return ""
 
 
-def parse_nitrocop_json(path: Path) -> tuple[set, dict] | None:
+def parse_nitrocop_json(path: Path) -> tuple[Counter, dict] | None:
     """Parse nitrocop JSON output. Format: {"offenses": [...]}
     Returns (offenses_set, messages_dict) or None if the file is missing/empty/unparseable.
     messages_dict maps (filepath, line, cop) -> message."""
@@ -99,7 +99,7 @@ def parse_nitrocop_json(path: Path) -> tuple[set, dict] | None:
     except json.JSONDecodeError:
         return None
 
-    offenses = set()
+    offenses: Counter[tuple[str, int, str]] = Counter()
     messages = {}
     for o in data.get("offenses", []):
         filepath = strip_repo_prefix(o.get("path", ""))
@@ -107,14 +107,14 @@ def parse_nitrocop_json(path: Path) -> tuple[set, dict] | None:
         cop = o.get("cop_name", "")
         if filepath and cop:
             key = (filepath, line, cop)
-            offenses.add(key)
+            offenses[key] += 1
             msg = o.get("message", "")
             if msg:
                 messages[key] = msg
     return offenses, messages
 
 
-def parse_rubocop_json(path: Path) -> tuple[set, dict, set, int, int] | None:
+def parse_rubocop_json(path: Path) -> tuple[Counter, dict, set, int, int] | None:
     """Parse RuboCop JSON output. Format: {"files": [{"path": ..., "offenses": [...]}]}
     Returns (offenses, messages, inspected_files, target_file_count, inspected_file_count)
     or None if the file is missing/empty/unparseable.
@@ -132,7 +132,7 @@ def parse_rubocop_json(path: Path) -> tuple[set, dict, set, int, int] | None:
     except json.JSONDecodeError:
         return None
 
-    offenses = set()
+    offenses: Counter[tuple[str, int, str]] = Counter()
     messages = {}
     inspected_files = set()
     zero_offense_files = set()
@@ -147,7 +147,7 @@ def parse_rubocop_json(path: Path) -> tuple[set, dict, set, int, int] | None:
             cop = o.get("cop_name", "")
             if filepath and cop:
                 key = (filepath, line, cop)
-                offenses.add(key)
+                offenses[key] += 1
                 msg = o.get("message", "")
                 if msg:
                     messages[key] = msg
@@ -280,8 +280,8 @@ def main():
 
         # Filter to covered cops only (drop offenses from cops nitrocop doesn't implement)
         if covered_cops is not None:
-            tc_offenses = {o for o in tc_offenses if o[2] in covered_cops}
-            rc_offenses = {o for o in rc_offenses if o[2] in covered_cops}
+            tc_offenses = Counter({k: v for k, v in tc_offenses.items() if k[2] in covered_cops})
+            rc_offenses = Counter({k: v for k, v in rc_offenses.items() if k[2] in covered_cops})
 
         # Only compare files RuboCop actually inspected. RuboCop silently drops
         # files when its parser crashes mid-batch, producing phantom FPs for every
@@ -306,21 +306,35 @@ def main():
         # check_cop.py doesn't run RuboCop, so it can't replicate the
         # file-filtering step. The unfiltered count is stored in the
         # artifact so check-cop can compare against it instead.
-        for _, _, cop in tc_offenses:
-            by_cop_unfiltered[cop] = by_cop_unfiltered.get(cop, 0) + 1
+        for key, count in tc_offenses.items():
+            cop = key[2]
+            by_cop_unfiltered[cop] = by_cop_unfiltered.get(cop, 0) + count
             if multi_repo:
-                by_repo_cop[repo_id][cop]["nitro_unfiltered"] += 1
+                by_repo_cop[repo_id][cop]["nitro_unfiltered"] += count
 
         if rc_inspected_files:
-            tc_offenses = {o for o in tc_offenses if o[0] in rc_inspected_files}
+            tc_offenses = Counter({k: v for k, v in tc_offenses.items() if k[0] in rc_inspected_files})
 
-        matches = tc_offenses & rc_offenses
-        fp = tc_offenses - rc_offenses  # nitrocop-only (false positives)
-        fn = rc_offenses - tc_offenses  # rubocop-only (false negatives)
+        # Counter arithmetic: compare offense multiplicities, not just presence
+        all_keys = set(tc_offenses) | set(rc_offenses)
+        n_matches = 0
+        n_fp = 0
+        n_fn = 0
+        fp_keys = []   # (key, excess) for example generation
+        fn_keys = []   # (key, deficit) for example generation
+        for key in all_keys:
+            tc = tc_offenses[key]
+            rc = rc_offenses[key]
+            n_matches += min(tc, rc)
+            excess = tc - rc
+            deficit = rc - tc
+            if excess > 0:
+                n_fp += excess
+                fp_keys.append((key, excess))
+            if deficit > 0:
+                n_fn += deficit
+                fn_keys.append((key, deficit))
 
-        n_matches = len(matches)
-        n_fp = len(fp)
-        n_fn = len(fn)
         total = n_matches + n_fp + n_fn
         match_rate = n_matches / total if total > 0 else 1.0
 
@@ -354,28 +368,31 @@ def main():
             return loc
 
         # Per-cop aggregation
-        for _, _, cop in matches:
-            by_cop_matches[cop] += 1
-            if multi_repo:
-                by_repo_cop[repo_id][cop]["matches"] += 1
-        for filepath, line, cop in sorted(fp):
-            by_cop_fp[cop] += 1
-            key = (filepath, line, cop)
+        for key in all_keys:
+            cop = key[2]
+            matched = min(tc_offenses[key], rc_offenses[key])
+            if matched > 0:
+                by_cop_matches[cop] += matched
+                if multi_repo:
+                    by_repo_cop[repo_id][cop]["matches"] += matched
+        for (filepath, line, cop), excess in sorted(fp_keys):
+            by_cop_fp[cop] += excess
             loc = f"{repo_id}: {filepath}:{line}" if multi_repo else f"{filepath}:{line}"
             # FP = nitrocop fires but RuboCop doesn't → message comes from nitrocop
+            key = (filepath, line, cop)
             msg = tc_messages.get(key, "")
             by_cop_fp_examples[cop].append(_make_example(loc, msg, filepath, line, cop))
             if multi_repo:
-                by_repo_cop[repo_id][cop]["fp"] += 1
-        for filepath, line, cop in sorted(fn):
-            by_cop_fn[cop] += 1
-            key = (filepath, line, cop)
+                by_repo_cop[repo_id][cop]["fp"] += excess
+        for (filepath, line, cop), deficit in sorted(fn_keys):
+            by_cop_fn[cop] += deficit
             loc = f"{repo_id}: {filepath}:{line}" if multi_repo else f"{filepath}:{line}"
             # FN = RuboCop fires but nitrocop doesn't → message comes from RuboCop
+            key = (filepath, line, cop)
             msg = rc_messages.get(key, "")
             by_cop_fn_examples[cop].append(_make_example(loc, msg, filepath, line, cop))
             if multi_repo:
-                by_repo_cop[repo_id][cop]["fn"] += 1
+                by_repo_cop[repo_id][cop]["fn"] += deficit
 
         result = {
             "repo": repo_id,
@@ -384,8 +401,8 @@ def main():
             "matches": n_matches,
             "fp": n_fp,
             "fn": n_fn,
-            "nitrocop_total": len(tc_offenses),
-            "rubocop_total": len(rc_offenses),
+            "nitrocop_total": sum(tc_offenses.values()),
+            "rubocop_total": sum(rc_offenses.values()),
             "files_inspected": len(rc_inspected_files),
         }
 

--- a/bench/corpus/resolve_symlink_paths.py
+++ b/bench/corpus/resolve_symlink_paths.py
@@ -36,7 +36,11 @@ def resolve_nitrocop_json(path: str) -> None:
         if filepath and os.path.exists(filepath):
             resolved = os.path.realpath(filepath)
             o["path"] = resolved
-        key = (o.get("path", ""), o.get("line", 0), o.get("cop_name", ""))
+        # Use column in dedup key to preserve genuine multi-offenses at
+        # different columns (e.g. two bad param names on one line) while
+        # still collapsing symlink duplicates (same physical location).
+        key = (o.get("path", ""), o.get("line", 0), o.get("cop_name", ""),
+               o.get("column", 0))
         if key not in seen:
             seen.add(key)
             deduped.append(o)
@@ -65,14 +69,17 @@ def resolve_rubocop_json(path: str) -> None:
             resolved = filepath
 
         if resolved in by_resolved:
-            # Merge offenses, deduplicating by (line, cop)
+            # Merge offenses, deduplicating by (line, cop, column) to preserve
+            # genuine multi-offenses at different columns on the same line.
             existing = by_resolved[resolved]
             existing_keys = {
-                (o.get("location", {}).get("line", 0), o.get("cop_name", ""))
+                (o.get("location", {}).get("line", 0), o.get("cop_name", ""),
+                 o.get("location", {}).get("start_column", 0))
                 for o in existing.get("offenses", [])
             }
             for o in f.get("offenses", []):
-                key = (o.get("location", {}).get("line", 0), o.get("cop_name", ""))
+                key = (o.get("location", {}).get("line", 0), o.get("cop_name", ""),
+                       o.get("location", {}).get("start_column", 0))
                 if key not in existing_keys:
                     existing["offenses"].append(o)
                     existing_keys.add(key)

--- a/bench/corpus/run_nitrocop.py
+++ b/bench/corpus/run_nitrocop.py
@@ -72,16 +72,19 @@ def build_env(repo_dir: str | None = None) -> dict[str, str]:
     return env
 
 
-def deduplicate_offenses(offenses: list[dict]) -> int:
-    """Count offenses deduplicated by (path, line, cop_name).
+def count_offenses(offenses: list[dict]) -> int:
+    """Count offenses by (path, line, cop_name) with multiplicity.
 
-    The corpus oracle uses this deduplication, so we must match it.
+    Multiple offenses at the same (path, line, cop) are counted separately
+    (e.g. two bad param names on one line). This matches the corpus oracle's
+    counter-based comparison.
     """
-    seen: set[tuple[str, int, str]] = set()
+    from collections import Counter
+    counter: Counter[tuple[str, int, str]] = Counter()
     for o in offenses:
         key = (o.get("path", ""), o.get("line", 0), o.get("cop_name", ""))
-        seen.add(key)
-    return len(seen)
+        counter[key] += 1
+    return sum(counter.values())
 
 
 def normalize_offenses(offenses: list[dict]) -> list[dict]:
@@ -91,8 +94,14 @@ def normalize_offenses(offenses: list[dict]) -> list[dict]:
     Local reruns need the same normalization so cops don't appear to regress
     purely because the same file was discovered via both canonical and symlink
     paths.
+
+    Uses (path, line, cop_name, column) as the dedup key so that genuine
+    multi-offenses at different columns on the same line are preserved
+    (e.g. two bad param names on ``def foo(a, b)``), while symlink
+    duplicates (same physical location via different discovery paths) are
+    still collapsed.
     """
-    seen: set[tuple[str, int, str]] = set()
+    seen: set[tuple[str, int, str, int]] = set()
     deduped: list[dict] = []
     for offense in offenses:
         normalized = offense.copy()
@@ -103,6 +112,7 @@ def normalize_offenses(offenses: list[dict]) -> list[dict]:
             normalized.get("path", ""),
             normalized.get("line", 0),
             normalized.get("cop_name", ""),
+            normalized.get("column", 0),
         )
         if key in seen:
             continue
@@ -156,7 +166,7 @@ def run_nitrocop(
     try:
         data = json.loads(result.stdout)
         offenses = normalize_offenses(data.get("offenses", []))
-        count = deduplicate_offenses(offenses)
+        count = count_offenses(offenses)
         return {"raw": result.stdout, "offenses": offenses, "count": count, "error": None}
     except json.JSONDecodeError as e:
         return {"raw": result.stdout, "offenses": [], "count": -1,

--- a/scripts/check_cop.py
+++ b/scripts/check_cop.py
@@ -552,6 +552,125 @@ def rerun_local_per_repo(
     )
 
 
+def _parse_example_loc(loc_str: str) -> tuple[str, str, int]:
+    """Parse 'repo_id: filepath:line' into (repo_id, filepath, line)."""
+    repo_id, rest = loc_str.split(": ", 1)
+    last_colon = rest.rfind(":")
+    filepath = rest[:last_colon]
+    line = int(rest[last_colon + 1:])
+    return repo_id, filepath, line
+
+
+def spot_check_examples(cop_name: str, data: dict) -> tuple[int, int, int, int]:
+    """Spot-check oracle FP/FN examples against local nitrocop.
+
+    Runs nitrocop on the specific files referenced in the oracle's fp_examples
+    and fn_examples, then checks whether each known issue persists or is resolved.
+
+    Returns (fp_remain, fp_resolved, fn_remain, fn_resolved).
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    from run_nitrocop import build_env, resolve_repo_config
+
+    by_cop = {c["cop"]: c for c in data.get("by_cop", [])}
+    cop_data = by_cop.get(cop_name)
+    if not cop_data:
+        return 0, 0, 0, 0
+
+    fp_examples = cop_data.get("fp_examples", [])
+    fn_examples = cop_data.get("fn_examples", [])
+    if not fp_examples and not fn_examples:
+        return 0, 0, 0, 0
+
+    corpus_dir = _get_corpus_dir()
+
+    # Collect all (repo_id, filepath, line, kind) we need to check
+    checks: list[tuple[str, str, int, str]] = []
+    for ex in fp_examples:
+        loc = ex["loc"] if isinstance(ex, dict) else ex
+        try:
+            repo_id, filepath, line = _parse_example_loc(loc)
+            checks.append((repo_id, filepath, line, "fp"))
+        except (ValueError, IndexError):
+            pass
+    for ex in fn_examples:
+        loc = ex["loc"] if isinstance(ex, dict) else ex
+        try:
+            repo_id, filepath, line = _parse_example_loc(loc)
+            checks.append((repo_id, filepath, line, "fn"))
+        except (ValueError, IndexError):
+            pass
+
+    # Group files by repo for batched execution
+    repo_files: dict[str, set[str]] = {}
+    for repo_id, filepath, _line, _kind in checks:
+        repo_files.setdefault(repo_id, set()).add(filepath)
+
+    # Run nitrocop on each repo's files and collect offense lines
+    nitrocop_lines: dict[tuple[str, str], set[int]] = {}
+
+    def _check_repo(repo_id: str, files: list[str]) -> dict[str, set[int]]:
+        repo_dir = corpus_dir / repo_id
+        existing = [fp for fp in files if (repo_dir / fp).exists()]
+        result_map: dict[str, set[int]] = {fp: set() for fp in files}
+        if not existing:
+            return result_map
+
+        env = build_env(str(repo_dir))
+        config = resolve_repo_config(repo_id, str(repo_dir))
+        cmd = [
+            str(NITROCOP_BIN), "--only", cop_name, "--format", "json",
+            "--no-cache", "--cache", "false", "--config", config, "--preview",
+        ] + [str(repo_dir / fp) for fp in existing]
+
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=120, env=env,
+            )
+            out = json.loads(result.stdout)
+            for o in out.get("offenses", []):
+                if o.get("cop_name") != cop_name:
+                    continue
+                line_num = o.get("line", 0)
+                offense_path = o.get("path", "")
+                for fp in existing:
+                    if offense_path.endswith(fp) or offense_path == str(repo_dir / fp):
+                        result_map[fp].add(line_num)
+                        break
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, KeyError):
+            pass
+        return result_map
+
+    workers = min(os.cpu_count() or 4, 16)
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(_check_repo, repo_id, sorted(files)): repo_id
+            for repo_id, files in repo_files.items()
+        }
+        for future in as_completed(futures):
+            repo_id = futures[future]
+            for filepath, lines in future.result().items():
+                nitrocop_lines[(repo_id, filepath)] = lines
+
+    # Evaluate each example
+    fp_remain = fp_resolved = fn_remain = fn_resolved = 0
+    for repo_id, filepath, line, kind in checks:
+        lines = nitrocop_lines.get((repo_id, filepath), set())
+        if kind == "fp":
+            if line in lines:
+                fp_remain += 1
+            else:
+                fp_resolved += 1
+        else:
+            if line in lines:
+                fn_resolved += 1
+            else:
+                fn_remain += 1
+
+    return fp_remain, fp_resolved, fn_remain, fn_resolved
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Check a cop against the corpus for aggregate count regressions")
@@ -852,6 +971,9 @@ def main():
     if file_drop_offenses > 0:
         print(f"  File-drop noise:      {file_drop_offenses:>10,}  "
               f"({len(file_drop_repos)} repos with RuboCop parser crashes)")
+        adjusted_excess = max(0, excess - file_drop_offenses)
+        print(f"  Excess (adjusted):    {adjusted_excess:>10,}  "
+              f"(excess minus file-drop noise)")
     print()
 
     print("  Gate type: count-only / cop-level regression")
@@ -963,6 +1085,24 @@ def main():
 
         if failed:
             sys.exit(1)
+
+        # Per-line spot-check: verify known FP/FN examples from the oracle.
+        # This catches regressions that cancel out in per-repo counts
+        # (e.g. +5 FP and -5 FN in the same repo = net 0 change).
+        fp_remain, fp_resolved, fn_remain, fn_resolved = spot_check_examples(
+            args.cop, data,
+        )
+        total_examples = fp_remain + fp_resolved + fn_remain + fn_resolved
+        if total_examples > 0:
+            print(f"  Spot-check ({total_examples} oracle examples):")
+            if fp_remain + fp_resolved > 0:
+                print(f"    FP: {fp_resolved} resolved, {fp_remain} remain "
+                      f"(of {fp_remain + fp_resolved})")
+            if fn_remain + fn_resolved > 0:
+                print(f"    FN: {fn_resolved} resolved, {fn_remain} remain "
+                      f"(of {fn_remain + fn_resolved})")
+            print()
+
         print("PASS: no per-repo regressions vs baseline")
         sys.exit(0)
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::process::Command;
 
 use anyhow::{Context, Result};
@@ -65,31 +65,63 @@ fn normalize_path(path: &str) -> &str {
     path.strip_prefix("./").unwrap_or(path)
 }
 
-fn diagnostics_to_set(diagnostics: &[Diagnostic]) -> HashSet<Offense> {
-    diagnostics
-        .iter()
-        .map(|d| {
-            let path = normalize_path(&d.path);
-            (path.to_string(), d.location.line, d.cop_name.clone())
-        })
-        .collect()
+type OffenseCounter = HashMap<Offense, usize>;
+
+fn diagnostics_to_counter(diagnostics: &[Diagnostic]) -> OffenseCounter {
+    let mut counter = OffenseCounter::new();
+    for d in diagnostics {
+        let path = normalize_path(&d.path);
+        let key = (path.to_string(), d.location.line, d.cop_name.clone());
+        *counter.entry(key).or_insert(0) += 1;
+    }
+    counter
 }
 
-fn rubocop_to_set(output: &RubocopOutput, covered: &HashSet<&str>) -> HashSet<Offense> {
-    output
-        .files
-        .iter()
-        .flat_map(|f| {
-            let path = normalize_path(&f.path);
-            f.offenses.iter().filter_map(move |o| {
-                if covered.contains(o.cop_name.as_str()) {
-                    Some((path.to_string(), o.location.start_line, o.cop_name.clone()))
-                } else {
-                    None
-                }
-            })
-        })
-        .collect()
+fn rubocop_to_counter(output: &RubocopOutput, covered: &HashSet<&str>) -> OffenseCounter {
+    let mut counter = OffenseCounter::new();
+    for f in &output.files {
+        let path = normalize_path(&f.path);
+        for o in &f.offenses {
+            if covered.contains(o.cop_name.as_str()) {
+                let key = (path.to_string(), o.location.start_line, o.cop_name.clone());
+                *counter.entry(key).or_insert(0) += 1;
+            }
+        }
+    }
+    counter
+}
+
+/// Compare two offense counters using multiset arithmetic.
+/// Returns (matches, fp, fn, per_cop_breakdown).
+fn counter_diff(
+    a: &OffenseCounter,
+    b: &OffenseCounter,
+) -> (usize, usize, usize, BTreeMap<String, CopStats>) {
+    let all_keys: HashSet<&Offense> = a.keys().chain(b.keys()).collect();
+    let mut total_matches = 0usize;
+    let mut total_fp = 0usize;
+    let mut total_fn = 0usize;
+    let mut per_cop: BTreeMap<String, CopStats> = BTreeMap::new();
+
+    for key in all_keys {
+        let ca = a.get(key).copied().unwrap_or(0);
+        let cb = b.get(key).copied().unwrap_or(0);
+        let matched = ca.min(cb);
+        let fp = ca.saturating_sub(cb);
+        let fn_ = cb.saturating_sub(ca);
+
+        total_matches += matched;
+        total_fp += fp;
+        total_fn += fn_;
+
+        let cop = &key.2;
+        let entry = per_cop.entry(cop.clone()).or_default();
+        entry.matches += matched;
+        entry.fp += fp;
+        entry.fn_ += fn_;
+    }
+
+    (total_matches, total_fp, total_fn, per_cop)
 }
 
 // ---------- Core verify logic ----------
@@ -104,7 +136,7 @@ pub fn run_verify(
     // 1. Run nitrocop internally
     let discovered = discover_files(&args.paths, config)?;
     let lint_result = run_linter(&discovered, config, registry, args, tier_map, allowlist);
-    let nitrocop_set = diagnostics_to_set(&lint_result.diagnostics);
+    let nitrocop_counter = diagnostics_to_counter(&lint_result.diagnostics);
 
     // 2. Run RuboCop subprocess
     let rubocop_json = run_rubocop(args)?;
@@ -113,37 +145,26 @@ pub fn run_verify(
 
     // 3. Build covered cop set
     let covered: HashSet<&str> = registry.cops().iter().map(|c| c.name()).collect();
-    let rubocop_set = rubocop_to_set(&rubocop_output, &covered);
+    let rubocop_counter = rubocop_to_counter(&rubocop_output, &covered);
 
-    // 4. Compute set operations
-    let matches: HashSet<&Offense> = nitrocop_set.intersection(&rubocop_set).collect();
-    let fps: HashSet<&Offense> = nitrocop_set.difference(&rubocop_set).collect();
-    let fns: HashSet<&Offense> = rubocop_set.difference(&nitrocop_set).collect();
-    let total = nitrocop_set.union(&rubocop_set).count();
+    // 4. Compute counter operations (multiset arithmetic)
+    let (n_matches, n_fp, n_fn, per_cop) = counter_diff(&nitrocop_counter, &rubocop_counter);
+
+    let nitrocop_count: usize = nitrocop_counter.values().sum();
+    let rubocop_count: usize = rubocop_counter.values().sum();
+    let total = n_matches + n_fp + n_fn;
     let match_rate = if total == 0 {
         100.0
     } else {
-        matches.len() as f64 / total as f64 * 100.0
+        n_matches as f64 / total as f64 * 100.0
     };
 
-    // 5. Per-cop breakdown
-    let mut per_cop: BTreeMap<String, CopStats> = BTreeMap::new();
-    for (_, _, cop) in &matches {
-        per_cop.entry(cop.clone()).or_default().matches += 1;
-    }
-    for (_, _, cop) in &fps {
-        per_cop.entry(cop.clone()).or_default().fp += 1;
-    }
-    for (_, _, cop) in &fns {
-        per_cop.entry(cop.clone()).or_default().fn_ += 1;
-    }
-
     Ok(VerifyResult {
-        nitrocop_count: nitrocop_set.len(),
-        rubocop_count: rubocop_set.len(),
-        matches: matches.len(),
-        false_positives: fps.len(),
-        false_negatives: fns.len(),
+        nitrocop_count,
+        rubocop_count,
+        matches: n_matches,
+        false_positives: n_fp,
+        false_negatives: n_fn,
         match_rate,
         per_cop,
     })
@@ -291,7 +312,7 @@ mod tests {
     }
 
     #[test]
-    fn rubocop_to_set_filters_covered_cops() {
+    fn rubocop_to_counter_filters_covered_cops() {
         let json = r#"{
             "files": [
                 {
@@ -314,13 +335,16 @@ mod tests {
 
         let output: RubocopOutput = serde_json::from_str(json).unwrap();
         let covered: HashSet<&str> = ["CoveredCop"].into_iter().collect();
-        let set = rubocop_to_set(&output, &covered);
-        assert_eq!(set.len(), 1);
-        assert!(set.contains(&("test.rb".to_string(), 1, "CoveredCop".to_string())));
+        let counter = rubocop_to_counter(&output, &covered);
+        assert_eq!(counter.len(), 1);
+        assert_eq!(
+            counter[&("test.rb".to_string(), 1, "CoveredCop".to_string())],
+            1
+        );
     }
 
     #[test]
-    fn diagnostics_to_set_normalizes_paths() {
+    fn diagnostics_to_counter_normalizes_paths() {
         let diags = vec![Diagnostic {
             path: "./foo/bar.rb".to_string(),
             location: crate::diagnostic::Location { line: 3, column: 0 },
@@ -329,8 +353,58 @@ mod tests {
             message: "msg".to_string(),
             corrected: false,
         }];
-        let set = diagnostics_to_set(&diags);
-        assert_eq!(set.len(), 1);
-        assert!(set.contains(&("foo/bar.rb".to_string(), 3, "Style/Test".to_string())));
+        let counter = diagnostics_to_counter(&diags);
+        assert_eq!(counter.len(), 1);
+        assert_eq!(
+            counter[&("foo/bar.rb".to_string(), 3, "Style/Test".to_string())],
+            1
+        );
+    }
+
+    #[test]
+    fn counter_preserves_multiplicity() {
+        // Two offenses by the same cop on the same line (e.g. two bad param names)
+        let diags = vec![
+            Diagnostic {
+                path: "test.rb".to_string(),
+                location: crate::diagnostic::Location { line: 1, column: 5 },
+                severity: crate::diagnostic::Severity::Convention,
+                cop_name: "Naming/MethodParameterName".to_string(),
+                message: "param a too short".to_string(),
+                corrected: false,
+            },
+            Diagnostic {
+                path: "test.rb".to_string(),
+                location: crate::diagnostic::Location { line: 1, column: 8 },
+                severity: crate::diagnostic::Severity::Convention,
+                cop_name: "Naming/MethodParameterName".to_string(),
+                message: "param b too short".to_string(),
+                corrected: false,
+            },
+        ];
+        let counter = diagnostics_to_counter(&diags);
+        // Same (path, line, cop) key, but count should be 2
+        let key = (
+            "test.rb".to_string(),
+            1,
+            "Naming/MethodParameterName".to_string(),
+        );
+        assert_eq!(counter[&key], 2);
+    }
+
+    #[test]
+    fn counter_diff_handles_multiplicity() {
+        let mut a = OffenseCounter::new();
+        let mut b = OffenseCounter::new();
+        let key = ("test.rb".to_string(), 1, "Cop/A".to_string());
+
+        // nitrocop fires 3 times, rubocop fires 2 times on same (path, line, cop)
+        a.insert(key.clone(), 3);
+        b.insert(key, 2);
+
+        let (matches, fp, fn_, _per_cop) = counter_diff(&a, &b);
+        assert_eq!(matches, 2); // min(3, 2)
+        assert_eq!(fp, 1); // 3 - 2
+        assert_eq!(fn_, 0); // 2 - 3 = 0
     }
 }


### PR DESCRIPTION
## Summary

- Switch all corpus comparison tools from set-based to counter/multiset-based offense comparison, preserving multiplicity when the same cop fires multiple times on one line (e.g. `Naming/MethodParameterName` on `def foo(a, b)`)
- Add adjusted excess display to `check_cop.py` that subtracts file-drop noise so the informational display isn't misleading
- Add per-line spot-check phase to `check_cop.py --rerun` that validates specific FP/FN examples from the oracle, catching regressions that cancel out in per-repo aggregate counts

## Files changed

- `src/verify.rs` — `HashSet<Offense>` → `HashMap<Offense, usize>` with `counter_diff()`
- `bench/corpus/diff_results.py` — `set` → `Counter` for offense parsing and comparison
- `bench/compare.rb` — `Set` → `Hash.new(0)` for counter arithmetic
- `bench/corpus/run_nitrocop.py` — `deduplicate_offenses` → `count_offenses`, column in dedup key
- `bench/corpus/resolve_symlink_paths.py` — add column to dedup key to preserve genuine multi-offenses
- `scripts/check_cop.py` — adjusted excess display + `spot_check_examples()`

## Test plan

- [x] `cargo test --release -- verify` (6 tests including new multiplicity tests)
- [x] `cargo clippy --release -- -D warnings`
- [x] `uv run ruff check` on all changed Python files
- [x] `uv run pytest tests/python/ --tb=short` (312 tests pass)
- [ ] End-to-end: `python3 scripts/check_cop.py Metrics/AbcSize --rerun` (high-noise cop)
- [ ] End-to-end: `python3 scripts/check_cop.py Naming/MethodParameterName --rerun` (multi-offense cop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)