### PR TITLE
Fix Metrics/MethodLength FP: use body end offset for =begin/=end

### DIFF
--- a/bench/corpus/smoke_baseline.json
+++ b/bench/corpus/smoke_baseline.json
@@ -8,18 +8,11 @@
     "rc_files": 35
   },
   "doorkeeper__doorkeeper__b305358": {
-    "fn": 302,
-    "fp": 14,
-    "matches": 13684,
+    "fn": 301,
+    "fp": 6,
+    "matches": 13685,
     "nc_files": 260,
-    "overlay_divergence": {
-      "fn": 5674,
-      "fp": 53,
-      "fp_delta": 39,
-      "match_delta": 5372,
-      "matches": 8312
-    },
-    "rate": 97.7,
+    "rate": 97.8,
     "rc_files": 260
   },
   "multi_json__multi_json__c5fa9fc": {
@@ -38,39 +31,25 @@
     "rc_files": 121
   },
   "rubocop__rubocop-rspec__51dab28": {
-    "fn": 473,
+    "fn": 436,
     "fp": 13,
-    "matches": 4168,
+    "matches": 4205,
     "nc_files": 288,
-    "overlay_divergence": {
-      "fn": 1888,
-      "fp": 10,
-      "fp_delta": -3,
-      "match_delta": 1415,
-      "matches": 2753
-    },
-    "rate": 89.6,
+    "rate": 90.4,
     "rc_files": 288
   },
   "ruby-formatter__rufo__a90e654": {
-    "fn": 528,
-    "fp": 21,
-    "matches": 10375,
+    "fn": 500,
+    "fp": 22,
+    "matches": 10403,
     "nc_files": 158,
-    "overlay_divergence": {
-      "fn": 6419,
-      "fp": 10,
-      "fp_delta": -11,
-      "match_delta": 5891,
-      "matches": 4484
-    },
-    "rate": 95.0,
+    "rate": 95.2,
     "rc_files": 158
   },
   "standardrb__standard__c886a57": {
-    "fn": 32,
+    "fn": 31,
     "fp": 3,
-    "matches": 3148,
+    "matches": 3149,
     "nc_files": 107,
     "rate": 98.9,
     "rc_files": 107

--- a/src/cop/metrics/method_length.rs
+++ b/src/cop/metrics/method_length.rs
@@ -175,6 +175,27 @@ use crate::parse::source::SourceFile;
 /// ConfigLMM (1), brandur (1), engineyard (1), gisiahq (1), samvera (1),
 /// siberas (1) — all config resolution or vendored file issues.
 /// No cop-level fix needed.
+///
+/// ## =begin/=end trailing embdoc fix (2026-03-30)
+///
+/// FP=7 root cause: methods containing `=begin/=end` embedded documentation
+/// blocks AFTER the last body statement were over-counted. RuboCop uses
+/// `body.source.lines` whose range ends at the last body statement. Any
+/// content between the body and the method's `end` keyword (including
+/// `=begin/=end` blocks) is outside `body.source` and not counted.
+///
+/// Previous fix attempt (commit 2785f494, reverted in 129fbc30) modified
+/// the shared `count_body_lines_impl` to skip `=begin/=end` blocks. This
+/// broke ClassLength/ModuleLength/BlockLength because those cops DO count
+/// `=begin/=end` content within the body range (it appears between
+/// statements, not after the last one).
+///
+/// Correct fix: in `count_method_lines`, use the body node's end offset
+/// (not the method's `end` keyword) as `effective_end_offset` for
+/// non-BeginNode, non-heredoc bodies. This shortens the counting range to
+/// match `body.source.lines` without modifying the shared counting function.
+/// BeginNode bodies are excluded because their location extends to the
+/// method's `end` keyword, so the adjustment would be a no-op.
 pub struct MethodLength;
 
 /// Parsed config values for MethodLength.
@@ -419,6 +440,25 @@ fn count_method_lines(
         } else {
             end_offset
         }
+    } else if body.as_begin_node().is_none() {
+        // RuboCop uses `body.source.lines` whose range ends at the last body
+        // statement. For non-BeginNode bodies (StatementsNode, single expressions),
+        // the body's location ends at the last statement — not the method's `end`
+        // keyword. Any content between the body's last statement and the method's
+        // `end` (e.g., =begin/=end embedded documentation blocks) is outside
+        // body.source and must not be counted.
+        //
+        // BeginNode is excluded because its location extends to the method's
+        // `end` keyword (same as end_offset), so this adjustment is a no-op.
+        let body_end_off = body
+            .location()
+            .end_offset()
+            .saturating_sub(1)
+            .max(body.location().start_offset());
+        let (body_end_line, _) = source.offset_to_line_col(body_end_off);
+        source
+            .line_col_to_offset(body_end_line + 1, 0)
+            .unwrap_or(end_offset)
     } else {
         end_offset
     };
@@ -1242,15 +1282,15 @@ mod tests {
     #[test]
     fn method_with_begin_end_comment() {
         use crate::testutil::run_cop_full;
-        // Method with =begin/=end multi-line comment block.
-        // RuboCop counts =begin/=end content as body lines (not excluded by
-        // CountComments: false, which only skips # comments).
-        // Body has 13 code lines + 4 =begin/=end lines = 17 (above Max:10).
+        // Method with =begin/=end multi-line comment block after the last statement.
+        // RuboCop uses body.source.lines which ends at the last statement, so
+        // =begin/=end blocks after the body are excluded. Only 13 code lines
+        // are counted (the =begin/=end block is not part of body.source).
         let source = b"class Foo\n  def test_method\n    begin\n      break 1\n    rescue => e\n      handle(e)\n      log(e)\n      report(e)\n    end\n\n    begin\n      yield 1\n    rescue => e\n      handle(e)\n      log(e)\n    end\n\n=begin\n    This is a multi-line comment.\n    Should not count as code.\n=end\n  end\nend\n";
         let diags = run_cop_full(&MethodLength, source);
         assert!(
             !diags.is_empty(),
-            "Method with =begin/=end comment should fire (17 body lines > Max:10)"
+            "Method with =begin/=end comment should fire (13 body lines > Max:10)"
         );
     }
 

--- a/tests/fixtures/cops/metrics/method_length/no_offense.rb
+++ b/tests/fixtures/cops/metrics/method_length/no_offense.rb
@@ -235,3 +235,23 @@ def compact_settings = {
   two: 2,
   three: 3
 }
+
+# =begin/=end embedded doc after body's last statement is excluded.
+# RuboCop uses body.source.lines which ends at the last body statement,
+# so =begin/=end blocks between the body and `end` are not counted.
+# 7 code lines + 6 =begin/=end lines = 13 physical, but only 7 count.
+def method_with_trailing_embdoc
+  if @descendant[0]
+    @descendant[0]
+  else
+    @descendant[0] = DescendantFont.new(self, 'latin')
+  end
+  call_something
+  call_another
+=begin
+  Original implementation was to reference @latinfont
+  directly but this was refactored to use DescendantFont
+  for proper font delegation and support.
+  See notes.
+=end
+end

--- a/tests/fixtures/cops/metrics/method_length/offense.rb
+++ b/tests/fixtures/cops/metrics/method_length/offense.rb
@@ -110,11 +110,12 @@ builder.define_method(:generated_method) do
   k = 11
 end
 
-# =begin/=end multi-line comments are counted as body lines by RuboCop.
-# RuboCop's comment_line? only matches # comments (regex /^\s*#/), so
-# =begin/=end content is always included regardless of CountComments.
+# =begin/=end after body's last statement is NOT counted by RuboCop.
+# RuboCop uses body.source.lines which ends at the last body statement,
+# so =begin/=end blocks between the body and `end` are excluded.
+# 13 code lines only (=begin/=end excluded).
 def method_with_begin_end_comment
-^^^ Metrics/MethodLength: Method has too many lines. [18/10]
+^^^ Metrics/MethodLength: Method has too many lines. [13/10]
   begin
     break 1
   rescue => e
@@ -131,9 +132,9 @@ def method_with_begin_end_comment
   end
 
 =begin
-  This is a multi-line comment. RuboCop counts =begin/=end
-  content as body lines (not skipped by CountComments: false).
-  Total body = 13 code lines + 5 =begin/=end lines = 18.
+  This is a multi-line comment. RuboCop does NOT count =begin/=end
+  content when it appears after the last body statement, because
+  body.source.lines ends at the last statement, not at `end`.
 =end
 end
 


### PR DESCRIPTION
## Summary
- Fix 7 false positives in Metrics/MethodLength caused by `=begin`/`=end` embedded documentation blocks after the last body statement
- Use body node's end offset instead of method's `end` keyword as the counting range boundary, matching RuboCop's `body.source.lines` behavior
- Unlike previous attempt (2785f494, reverted in 129fbc30), this does NOT modify the shared `count_body_lines_impl` — only adjusts the range in `count_method_lines`, so ClassLength/ModuleLength/BlockLength are unaffected

## Test plan
- [x] All 131 Metrics cop tests pass
- [x] Full test suite passes (4,514 tests)
- [x] `verify_cop_locations.py`: all 7 FPs verified fixed, 0 remain
- [x] Corpus smoke test passes (baseline improved for 4 repos)
- [ ] Corpus oracle confirmation pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)