### PR TITLE
Add scan_root relativization for per-cop Include patterns

### DIFF
--- a/docs/investigations/rails_include_fps.md
+++ b/docs/investigations/rails_include_fps.md
@@ -1,26 +1,38 @@
-# Rails cop Include pattern FPs
+# Rails cop Include pattern regressions
 
 ## Problem
 
-~1,300 FPs across multiple Rails cops with per-cop `Include` patterns from
-`rubocop-rails`'s `config/default.yml`. Nitrocop fires on ALL files instead of
-restricting to the Include-specified paths.
+~1,300 regressions across multiple Rails cops with per-cop `Include` patterns from
+`rubocop-rails`'s `config/default.yml`. Nitrocop can't match Include-specified paths
+because none of the existing relativization strategies produce the right repo-relative
+path when `base_dir` differs from the scan target (repo root).
 
 Affected cops (from corpus oracle run 23718439425):
 
-| Cop | FP | Matches | Include pattern |
+| Cop | Regressions | Matches | Include pattern |
 |-----|---:|--------:|-----------------|
 | Rails/I18nLocaleAssignment | 560 | 722 | `spec/**/*.rb`, `test/**/*.rb` |
 | Rails/ActionControllerTestCase | 387 | 1,306 | `**/test/**/*.rb` |
 | Rails/EnumSyntax | 194 | 256 | (default) |
 | Rails/TimeZoneAssignment | 191 | 277 | `spec/**/*.rb`, `test/**/*.rb` |
 
+**Direction**: If Include patterns are loaded (Some) but the glob can't match any
+file path, `is_included()` returns false → cop doesn't run → FN (missed offenses).
+If Include patterns fail to load (None → match all), cops fire on all files → FP
+(extra offenses). The BUNDLE_GEMFILE env var in `run_nitrocop.py:68` suggests gem
+resolution should succeed, making the likely behavior FN. The regression column above
+may contain a mix of both depending on the oracle run's gem resolution state.
+
+**Verification**: Check corpus oracle stderr for `warning: require 'rubocop-rails'`
+lines — their presence would confirm gem loading failure (FP case); absence confirms
+patterns are loaded but can't match (FN case).
+
 ## Root cause
 
 When nitrocop uses a non-dotfile config (e.g., `baseline_rubocop.yml`), `base_dir`
 is set to `CWD` per RuboCop's `base_dir_for_path_parameters` convention.
 
-In `is_cop_match` (`src/config/mod.rs:294-343`), Include patterns are matched
+In `is_cop_match` (`src/config/mod.rs`), Include patterns are matched
 against file paths relativized to `config_dir`, `base_dir`, or stripped of `./`:
 
 ```rust
@@ -31,15 +43,19 @@ let included = filter.is_included(path)
 ```
 
 In the corpus oracle:
-- CWD = workspace root (e.g., `/home/runner/work/nitrocop/nitrocop`)
+- CWD = `/tmp` (via `run_nitrocop.py`, to avoid .gitignore interference)
+- `base_dir` = `/tmp` (non-dotfile config → CWD)
 - Files are at `/home/runner/.../repos/REPO_ID/spec/foo.rb`
-- `strip_prefix(base_dir)` → `repos/REPO_ID/spec/foo.rb`
-- Pattern `spec/**/*.rb` doesn't match `repos/REPO_ID/spec/foo.rb`
-- Result: Include filter never matches → cop runs on ALL files (no Include = match all)
+- `strip_prefix(/tmp)` fails (different path tree)
+- `config_dir` = `/tmp/nitrocop_corpus_configs/` (overlay parent)
+- `strip_prefix(config_dir)` also fails
+- Pattern `spec/**/*.rb` doesn't match any relativized form
+- Result: `is_included()` returns false → cop doesn't run → FN
 
-Wait — `None` include means match all. The Include patterns ARE loaded from the
-gem, so `include_set` is `Some(...)`. But the glob never matches because paths
-have extra prefix.
+Note: `run_nitrocop.py:68` sets `BUNDLE_GEMFILE` and `BUNDLE_PATH` env vars
+pointing to `bench/corpus/`, so `bundle info --path rubocop-rails` should succeed
+regardless of CWD. Include patterns from the gem config are likely loaded
+as `Some(GlobSet)`.
 
 ## What RuboCop does differently
 
@@ -54,13 +70,9 @@ def file_name_matches_any?(file, parameter, default_result)
 end
 ```
 
-Matches against both the config-relative path AND the original file path.
-RuboCop's `relevant_file?` is called with `processed_source.file_path` which
-may already be in a form that matches (e.g., repo-relative).
-
-**Key question**: What does `processed_source.file_path` look like in the corpus
-oracle? If RuboCop internally converts to repo-relative paths, that would explain
-why `spec/**/*.rb` matches for RuboCop but not nitrocop.
+RuboCop is typically invoked from the repo root with a `.rubocop.yml` in the repo,
+so `processed_source.file_path` is repo-relative (e.g., `spec/foo.rb`), making
+Include patterns like `spec/**/*.rb` match naturally.
 
 ## Attempted fix: CWD change (reverted)
 
@@ -68,21 +80,21 @@ Changed `run_nitrocop.py` to use `cwd=repo_dir` instead of `cwd=/tmp`. This made
 `base_dir` = repo root, so `strip_prefix(base_dir)` correctly produced
 `spec/foo.rb` from `/abs/repo/spec/foo.rb`.
 
-**Reverted** because it introduced +280 new FPs — changing `base_dir` globally
-affected ALL pattern resolution (Exclude, AllCops.Exclude, etc.), not just
-per-cop Include.
+**Reverted** (commit `44c00c43`) because it introduced +280 new regressions — changing
+`base_dir` globally affected ALL pattern resolution (Exclude, AllCops.Exclude, etc.),
+not just per-cop Include.
 
-## Proper fix direction
+## Fix: scan_root relativization for Include only
 
-Fix `is_cop_match` to also try relativizing against the **scan root** (the
-target directory passed on the command line). The scan root is available as
-`DiscoveredFiles` context or could be stored in `CopFilterSet`.
-
-For Include matching only (not Exclude — see `mod.rs:206-211` for why Exclude
-must NOT use scan root), add:
+Added `scan_roots` (CLI target directories) to `CopFilterSet`. In `is_cop_match`,
+file paths are also relativized against each scan root, but ONLY for Include
+matching — NOT for Exclude (see `mod.rs:206-213` for why Exclude must NOT use
+scan roots).
 
 ```rust
-let rel_to_scan_root = scan_root.and_then(|sr| path.strip_prefix(sr).ok());
+let rel_to_scan_root: Option<&Path> = self.scan_roots.iter()
+    .find_map(|sr| path.strip_prefix(sr).ok());
+
 let included = filter.is_included(path)
     || rel_path.is_some_and(|rel| filter.is_included(rel))
     || rel_to_base.is_some_and(|rel| filter.is_included(rel))
@@ -90,14 +102,9 @@ let included = filter.is_included(path)
     || stripped.is_some_and(|s| filter.is_included(s));
 ```
 
-This would need:
-1. Storing scan roots in `CopFilterSet` (from CLI args or `discover_files`)
-2. Using them only for Include matching
-3. Testing that Exclude behavior doesn't change
-
 ## Related
 
-- `docs/investigations/investigation-target-dir-relativization.md` — may have
-  prior analysis on scan root relativization
-- `src/config/mod.rs:206-211` — comment explaining why scan_roots was removed
+- `docs/investigations/investigation-target-dir-relativization.md` — prior analysis
+  on scan root relativization
+- `src/config/mod.rs:206-213` — comment explaining why scan_roots was removed
   for AllCops.Exclude (smoke test regressions)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -161,6 +161,14 @@ pub struct CopFilterSet {
     /// 14-digit run that is <= this value have all offenses suppressed.
     /// Implements rubocop-rails' MigrationFileSkippable behavior.
     migrated_schema_version: Option<String>,
+    /// CLI target directories (scan roots) for Include pattern relativization.
+    /// Per-cop Include patterns (e.g., `spec/**/*.rb` from rubocop-rails) are
+    /// repo-relative. When base_dir != repo root (e.g., non-dotfile config with
+    /// CWD=/tmp), file paths can't be relativized to match. Scan roots provide
+    /// a fallback: strip the scan target prefix to get a repo-relative path.
+    /// Used ONLY for Include matching — NOT for Exclude (see comment at
+    /// `is_globally_excluded` for why scan_roots must not affect Exclude).
+    scan_roots: Vec<PathBuf>,
 }
 
 impl CopFilterSet {
@@ -317,12 +325,24 @@ impl CopFilterSet {
         // that don't start with `./` won't match.
         let stripped = path.strip_prefix("./").ok();
 
+        // Scan-root relativization for Include patterns ONLY.
+        // Per-cop Include patterns (e.g., `spec/**/*.rb` from rubocop-rails)
+        // are repo-relative. When base_dir != repo root (e.g., non-dotfile
+        // config with CWD=/tmp), strip_prefix(base_dir) can't produce the
+        // right relative path. Try each scan root (CLI target directory) as
+        // a fallback. NOT used for Exclude — see comment at is_globally_excluded.
+        let rel_to_scan_root: Option<&Path> = self
+            .scan_roots
+            .iter()
+            .find_map(|sr| path.strip_prefix(sr).ok());
+
         // Include: file must match on at least one path form.
         // This supports both absolute patterns (/tmp/test/db/**) and
         // relative patterns (db/migrate/**).
         let included = filter.is_included(path)
             || rel_path.is_some_and(|rel| filter.is_included(rel))
             || rel_to_base.is_some_and(|rel| filter.is_included(rel))
+            || rel_to_scan_root.is_some_and(|rel| filter.is_included(rel))
             || stripped.is_some_and(|s| filter.is_included(s));
         if !included {
             return false;
@@ -2553,6 +2573,7 @@ impl ResolvedConfig {
         registry: &CopRegistry,
         tier_map: &crate::cop::tiers::TierMap,
         preview: bool,
+        scan_roots: &[PathBuf],
     ) -> CopFilterSet {
         // Build global exclude set (globs + regexes)
         let global_exclude_pats: Vec<&str> =
@@ -2781,6 +2802,7 @@ impl ResolvedConfig {
             universal_cop_indices,
             pattern_cop_indices,
             migrated_schema_version: self.migrated_schema_version.clone(),
+            scan_roots: scan_roots.to_vec(),
         }
     }
 
@@ -3488,6 +3510,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
         // Glob pattern should work
         assert!(
@@ -3573,6 +3596,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
 
         assert!(
@@ -3610,6 +3634,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
 
         assert!(
@@ -3636,7 +3661,7 @@ mod tests {
         let config = load_config(Some(&dir.join(".rubocop.yml")), None, None).unwrap();
         let registry = crate::cop::registry::CopRegistry::default_registry();
         let tier_map = crate::cop::tiers::TierMap::load();
-        let filters = config.build_cop_filters(&registry, &tier_map, true);
+        let filters = config.build_cop_filters(&registry, &tier_map, true, &[]);
         let index = registry
             .cops()
             .iter()
@@ -4233,7 +4258,7 @@ mod tests {
         // Also verify through build_cop_filters (the production path)
         let registry = crate::cop::registry::CopRegistry::default_registry();
         let tier_map = crate::cop::tiers::TierMap::load();
-        let filters = config.build_cop_filters(&registry, &tier_map, false);
+        let filters = config.build_cop_filters(&registry, &tier_map, false, &[]);
         let rcb_idx = registry
             .cops()
             .iter()
@@ -4640,6 +4665,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
         let path = Path::new("bench/repos/mastodon/lib/tasks/emojis.rake");
         assert!(
@@ -4663,6 +4689,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
         let path = Path::new("/tmp/test/db/migrate/001_create_users.rb");
         assert!(
@@ -4687,6 +4714,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
         let path = Path::new("bench/repos/discourse/spec/models/user_spec.rb");
         assert!(
@@ -4711,6 +4739,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
         let path = Path::new("bench/repos/discourse/spec/requests/api/invites_spec.rb");
         assert!(
@@ -4734,6 +4763,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
         assert!(filter_set.is_cop_match(0, Path::new("app/models/user.rb")));
         assert!(!filter_set.is_cop_match(0, Path::new("vendor/gems/foo.rb")));
@@ -4753,6 +4783,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
         assert!(!filter_set.is_cop_match(0, Path::new("anything.rb")));
     }
@@ -4787,6 +4818,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
 
         // Positive: files under cookbooks/ should be excluded
@@ -4844,6 +4876,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: vec![0],
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
 
         // Cop should match files under lib/ even with absolute excludes present
@@ -4879,6 +4912,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
         // File doesn't match Include, but is_cop_excluded only checks Exclude
         assert!(
@@ -4901,6 +4935,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
         assert!(
             filter_set.is_cop_excluded(0, Path::new("/project/app/controllers/test.rb")),
@@ -4928,6 +4963,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
         // File in sub-config dir: nearest_config_dir is the sub-dir,
         // but root-relative path should still match the Exclude pattern.
@@ -4954,6 +4990,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: Some("19700101000000".to_string()),
+            scan_roots: vec![],
         };
         // SHA hash containing 14-digit run <= 19700101000000 → migrated
         assert!(filter_set.is_migrated_file(Path::new(
@@ -4981,6 +5018,7 @@ mod tests {
             universal_cop_indices: Vec::new(),
             pattern_cop_indices: Vec::new(),
             migrated_schema_version: None,
+            scan_roots: vec![],
         };
         assert!(!no_version.is_migrated_file(Path::new("19700101000000_init.rb")));
     }
@@ -5577,6 +5615,88 @@ mod tests {
         assert!(
             config.is_cop_enabled("FakePerf2/CopB", Path::new("a.rb"), &[], &[]),
             "FakePerf2/CopB should be enabled (user explicitly enabled dept)"
+        );
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn scan_root_enables_include_matching() {
+        // When Include patterns exist but file paths have a prefix that
+        // prevents matching via base_dir/config_dir, scan_roots provides
+        // a fallback by relativizing against the CLI target directory.
+        let dir = std::env::temp_dir().join("nitrocop_test_scan_root_include");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        // Create a config with a cop that has Include: spec/**/*.rb
+        let path = write_config(
+            &dir,
+            "Style/FrozenStringLiteralComment:\n  Include:\n    - 'spec/**/*.rb'\n",
+        );
+        let config = load_config(Some(&path), None, None).unwrap();
+        let registry = crate::cop::registry::CopRegistry::default_registry();
+        let tier_map = crate::cop::tiers::TierMap::load();
+
+        let scan_root = PathBuf::from("/fake/repo");
+
+        // Without scan_roots: file outside base_dir/config_dir won't match Include
+        let filters_no_scan = config.build_cop_filters(&registry, &tier_map, true, &[]);
+        let idx = registry
+            .cops()
+            .iter()
+            .position(|c| c.name() == "Style/FrozenStringLiteralComment")
+            .unwrap();
+        assert!(
+            !filters_no_scan.is_cop_match(idx, Path::new("/fake/repo/spec/foo.rb")),
+            "Without scan_roots, Include pattern should not match"
+        );
+
+        // With scan_roots: scan_root relativization enables matching
+        let filters_with_scan =
+            config.build_cop_filters(&registry, &tier_map, true, &[scan_root.clone()]);
+        assert!(
+            filters_with_scan.is_cop_match(idx, Path::new("/fake/repo/spec/foo.rb")),
+            "With scan_roots, spec/foo.rb should match Include spec/**/*.rb"
+        );
+        assert!(
+            !filters_with_scan.is_cop_match(idx, Path::new("/fake/repo/app/foo.rb")),
+            "app/foo.rb should NOT match Include spec/**/*.rb even with scan_roots"
+        );
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn scan_root_does_not_affect_exclude() {
+        // Scan roots must NOT be used for Exclude matching — only Include.
+        // See comment at is_globally_excluded for why.
+        let dir = std::env::temp_dir().join("nitrocop_test_scan_root_exclude");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        // Create a cop with Exclude: vendor/**/*
+        let path = write_config(
+            &dir,
+            "Style/FrozenStringLiteralComment:\n  Exclude:\n    - 'vendor/**/*'\n",
+        );
+        let config = load_config(Some(&path), None, None).unwrap();
+        let registry = crate::cop::registry::CopRegistry::default_registry();
+        let tier_map = crate::cop::tiers::TierMap::load();
+
+        let scan_root = PathBuf::from("/fake/repo");
+        let filters = config.build_cop_filters(&registry, &tier_map, true, &[scan_root]);
+        let idx = registry
+            .cops()
+            .iter()
+            .position(|c| c.name() == "Style/FrozenStringLiteralComment")
+            .unwrap();
+
+        // vendor/foo.rb relative to scan_root should NOT be excluded,
+        // because Exclude does not use scan_root relativization
+        assert!(
+            filters.is_cop_match(idx, Path::new("/fake/repo/vendor/foo.rb")),
+            "Exclude should NOT use scan_root — vendor/foo.rb should still match"
         );
 
         fs::remove_dir_all(&dir).ok();

--- a/src/cop/lint/syntax.rs
+++ b/src/cop/lint/syntax.rs
@@ -160,7 +160,7 @@ mod tests {
         let registry = CopRegistry::default_registry();
         let tier_map = TierMap::load();
         let config = ResolvedConfig::empty();
-        let cop_filters = config.build_cop_filters(&registry, &tier_map, true);
+        let cop_filters = config.build_cop_filters(&registry, &tier_map, true, &[]);
         let base_configs = config.precompute_cop_configs(&registry);
         let args = syntax_only_args();
         let allowlist = crate::cop::autocorrect_allowlist::AutocorrectAllowlist::load();
@@ -221,7 +221,7 @@ mod tests {
         let registry = CopRegistry::default_registry();
         let tier_map = TierMap::load();
         let config = ResolvedConfig::empty();
-        let cop_filters = config.build_cop_filters(&registry, &tier_map, true);
+        let cop_filters = config.build_cop_filters(&registry, &tier_map, true, &[]);
         let args = syntax_only_args();
 
         // Use emit_invalid_utf8_diagnostic through lint_file indirectly.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ fn collect_corpus_check_results(
     schema::init(config.config_dir());
 
     // Precompute cop filters and configs once
-    let cop_filters = config.build_cop_filters(registry, tier_map, args.preview);
+    let cop_filters = config.build_cop_filters(registry, tier_map, args.preview, &args.paths);
     let base_configs = config.precompute_cop_configs(registry);
     let has_dir_overrides = config.has_dir_overrides();
 
@@ -429,7 +429,7 @@ pub fn run(args: Args) -> Result<i32> {
 
     // --list-target-files (-L): print files that would be linted, then exit
     if args.list_target_files {
-        let cop_filters = config.build_cop_filters(&registry, &tier_map, args.preview);
+        let cop_filters = config.build_cop_filters(&registry, &tier_map, args.preview, &args.paths);
         for file in &discovered.files {
             if cop_filters.is_globally_excluded(file) {
                 let is_explicit = discovered.explicit.contains(file)

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -134,7 +134,7 @@ pub fn lint_source(
     tier_map: &TierMap,
     allowlist: &crate::cop::autocorrect_allowlist::AutocorrectAllowlist,
 ) -> LintResult {
-    let cop_filters = config.build_cop_filters(registry, tier_map, args.preview);
+    let cop_filters = config.build_cop_filters(registry, tier_map, args.preview, &args.paths);
     let base_configs = config.precompute_cop_configs(registry);
     let has_dir_overrides = config.has_dir_overrides();
     let (diagnostics, _corrected_bytes, corrected_count) = lint_source_inner(
@@ -175,7 +175,7 @@ pub fn run_linter(
     crate::schema::init(config.config_dir());
 
     // Build cop filters once before the parallel loop
-    let cop_filters = config.build_cop_filters(registry, tier_map, args.preview);
+    let cop_filters = config.build_cop_filters(registry, tier_map, args.preview, &args.paths);
     // Pre-compute base cop configs once (avoids HashMap clone per cop per file)
     let base_configs = config.precompute_cop_configs(registry);
     let has_dir_overrides = config.has_dir_overrides();
@@ -821,7 +821,7 @@ fn emit_syntax_diagnostics(
     };
     let owned_filters;
     let active_filters = if let Some(ref file_config) = effective_config {
-        owned_filters = file_config.build_cop_filters(registry, tier_map, args.preview);
+        owned_filters = file_config.build_cop_filters(registry, tier_map, args.preview, &[]);
         &owned_filters
     } else {
         cop_filters
@@ -903,7 +903,7 @@ pub(crate) fn emit_invalid_utf8_diagnostic(
     };
     let owned_filters;
     let active_filters = if let Some(ref file_config) = effective_config {
-        owned_filters = file_config.build_cop_filters(registry, tier_map, args.preview);
+        owned_filters = file_config.build_cop_filters(registry, tier_map, args.preview, &[]);
         &owned_filters
     } else {
         cop_filters
@@ -1012,7 +1012,7 @@ fn lint_source_once(
     let owned_filters;
     let owned_base_configs;
     let (active_filters, active_base_configs) = if let Some(ref file_config) = effective_config {
-        owned_filters = file_config.build_cop_filters(registry, tier_map, args.preview);
+        owned_filters = file_config.build_cop_filters(registry, tier_map, args.preview, &[]);
         owned_base_configs = file_config.precompute_cop_configs(registry);
         (&owned_filters, owned_base_configs.as_slice())
     } else {


### PR DESCRIPTION
## Summary

- Per-cop Include patterns from gem configs (e.g., `spec/**/*.rb` from rubocop-rails) fail to match when `base_dir` differs from the repo root (non-dotfile configs where base_dir=CWD)
- Adds `scan_roots` (CLI target directories) to `CopFilterSet` as a fallback relativization for Include matching only — NOT Exclude, per existing `mod.rs:206-213` guidance
- Corrects the investigation doc's FP/FN analysis and documents the BUNDLE_GEMFILE env var behavior

## Test plan

- [x] Unit test: `scan_root_enables_include_matching` — verifies Include patterns match via scan_root relativization
- [x] Unit test: `scan_root_does_not_affect_exclude` — verifies Exclude is NOT affected by scan_roots
- [x] Full test suite passes (4379 unit + 129 integration)
- [ ] Corpus verification with `check_cop.py --rerun` for affected Rails cops (Rails/I18nLocaleAssignment, Rails/ActionControllerTestCase, Rails/TimeZoneAssignment, Rails/EnumSyntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)