### PR TITLE
Skip hidden-directory files in git-tracked file discovery

### DIFF
--- a/bench/corpus/smoke_baseline.json
+++ b/bench/corpus/smoke_baseline.json
@@ -16,18 +16,11 @@
     "rc_files": 260
   },
   "multi_json__multi_json__c5fa9fc": {
-    "fn": 16,
+    "fn": 11,
     "fp": 1,
-    "matches": 5933,
+    "matches": 5938,
     "nc_files": 121,
-    "overlay_divergence": {
-      "fn": 2412,
-      "fp": 11,
-      "fp_delta": 10,
-      "match_delta": 2396,
-      "matches": 3537
-    },
-    "rate": 99.7,
+    "rate": 99.8,
     "rc_files": 121
   },
   "rubocop__rubocop-rspec__51dab28": {
@@ -39,11 +32,11 @@
     "rc_files": 288
   },
   "ruby-formatter__rufo__a90e654": {
-    "fn": 500,
+    "fn": 429,
     "fp": 22,
-    "matches": 10403,
+    "matches": 10474,
     "nc_files": 158,
-    "rate": 95.2,
+    "rate": 95.9,
     "rc_files": 158
   },
   "standardrb__standard__c886a57": {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -116,6 +116,13 @@ fn tracked_ruby_files(dir: &Path) -> Vec<PathBuf> {
         .lines()
         .filter_map(|line| {
             let rel_from_root = Path::new(line);
+            // Skip files under hidden directories (e.g. .jbundler/, .rbnext/).
+            // RuboCop's TargetFinder skips paths containing "/." via hidden_path?.
+            // The WalkBuilder already filters these from the directory walk, but
+            // git ls-files returns them unconditionally.
+            if has_hidden_dir_component(rel_from_root) {
+                return None;
+            }
             let rel_to_dir = if rel_prefix.as_os_str().is_empty() {
                 rel_from_root
             } else {
@@ -186,6 +193,29 @@ const RUBY_FILENAMES: &[&str] = &[
     "Vagabondfile",
     "Vagrantfile",
 ];
+
+/// Returns true if any directory component of the path starts with a dot
+/// (excluding `.` and `..`). Matches RuboCop's `hidden_path?` which checks
+/// for `File::SEPARATOR + "."` in the path string.
+fn has_hidden_dir_component(path: &Path) -> bool {
+    use std::path::Component;
+    let mut components = path.components().peekable();
+    while let Some(component) = components.next() {
+        // Skip the last component (filename) — hidden filenames like .pryrc
+        // are legitimate Ruby targets, only hidden *directories* are skipped.
+        if components.peek().is_none() {
+            break;
+        }
+        if let Component::Normal(name) = component {
+            if let Some(s) = name.to_str() {
+                if s.starts_with('.') && s != "." && s != ".." {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
 
 fn is_ruby_file(path: &Path) -> bool {
     // Check by extension


### PR DESCRIPTION
## Summary
- RuboCop's `TargetFinder` skips files in hidden directories (paths containing `/.` like `.jbundler/`, `.rbnext/`) via `hidden_path?`
- nitrocop's `WalkBuilder` directory walk already filters these (`.hidden(true)`), but `tracked_ruby_files()` returned them unconditionally from `git ls-files`
- This caused nitrocop to discover and lint files that RuboCop never processes, creating phantom FP across multiple cops (e.g. Style/Copyright in `.rbnext/`, Style/OptionHash in `.jbundler/`)

## Changes
- Added `has_hidden_dir_component()` filter to `tracked_ruby_files()` in `src/fs.rs`
- Only filters hidden *directory* components, not hidden filenames (e.g. `.pryrc` is still discovered)
- Matches RuboCop's `HIDDEN_PATH_SUBSTRING = "#{File::SEPARATOR}."` check

## Test plan
- [x] `cargo test --release` — all 4394 tests pass
- [x] `corpus_smoke_test.py` — PASS, improved 2 repos (multi_json, rufo)
- [ ] CI cop-check shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)