### PR TITLE
Fix Rails/ActionControllerFlashBeforeRender FP in multi-stmt begin/rescue

### DIFF
--- a/src/cop/rails/action_controller_flash_before_render.rs
+++ b/src/cop/rails/action_controller_flash_before_render.rs
@@ -13,6 +13,12 @@
 /// - Root cause 22 (FP): `case ... else` branches with `flash` followed by an
 ///   outer `redirect_to` were treated like `when` branches. RuboCop only allows
 ///   that suppression for the `else` branch shape seen in the corpus.
+/// - Root cause 23 (FP=2): `check_begin_body_with_rescue` passed rescue_context_nodes
+///   (the rescue clause nodes containing render) as outer_siblings to nested if/unless.
+///   In RuboCop, `each_ancestor(:if, :rescue)` finds the if/unless ancestor BEFORE
+///   the rescue ancestor. The if/unless node's right_siblings are the remaining begin
+///   body stmts, not the rescue clause content. Fixed by passing inner_remaining
+///   (remaining begin body stmts) to nested if/unless instead of rescue_context_nodes.
 ///
 /// Investigation findings (2026-03-18):
 /// - Root cause 1: `default_include` was set to `["app/controllers/**/*.rb"]` but the vendor
@@ -520,13 +526,34 @@ impl FlashVisitor<'_> {
         begin_stmts: &[ruby_prism::Node<'_>],
         rescue_context_nodes: &[ruby_prism::Node<'_>],
     ) {
-        for stmt in begin_stmts {
+        // In Parser AST, when the begin body has a single statement, that statement
+        // is a direct child of the rescue node (no begin wrapper). Its right_siblings
+        // include the resbody nodes. When the body has multiple statements, they're
+        // wrapped in a begin node, and each statement's right_siblings are the other
+        // statements within the begin (not the resbody nodes).
+        let single_stmt_body = begin_stmts.len() == 1;
+
+        for (i, stmt) in begin_stmts.iter().enumerate() {
+            let inner_remaining = &begin_stmts[i + 1..];
+
+            // For if/unless: in single-stmt bodies, the node is a direct child of
+            // rescue, so its right_siblings include resbody (use rescue_context_nodes).
+            // In multi-stmt bodies, it's inside a begin wrapper, so right_siblings
+            // are the remaining begin body stmts (use inner_remaining).
+            let if_unless_outer = if single_stmt_body {
+                rescue_context_nodes
+            } else {
+                inner_remaining
+            };
+
             if let Some(nested_if) = stmt.as_if_node() {
-                self.check_if_node_with_outer(&nested_if, rescue_context_nodes);
+                self.check_if_node_with_outer(&nested_if, if_unless_outer);
             }
             if let Some(nested_unless) = stmt.as_unless_node() {
-                self.check_unless_node_with_outer(&nested_unless, rescue_context_nodes);
+                self.check_unless_node_with_outer(&nested_unless, if_unless_outer);
             }
+            // begin/case/embedded: not :if or :rescue in Parser AST, so rescue
+            // ancestor is found — keep using rescue_context_nodes.
             if let Some(nested_begin) = stmt.as_begin_node() {
                 self.check_begin_node_with_outer(&nested_begin, rescue_context_nodes);
             }

--- a/tests/fixtures/cops/rails/action_controller_flash_before_render/no_offense.rb
+++ b/tests/fixtures/cops/rails/action_controller_flash_before_render/no_offense.rb
@@ -373,7 +373,8 @@ class EnumerationsController < ApplicationController
   end
 end
 
-# FP guard: render inside an unless branch in a begin body should stay ignored
+# FP guard: flash in unless inside begin body — rescue has render but
+# RuboCop finds the unless ancestor first, not rescue (root cause 23)
 class TarUploadsController < ApplicationController
   def create_from_tar
     begin
@@ -382,26 +383,36 @@ class TarUploadsController < ApplicationController
         flash[:html_safe] = true
         render(action: "new") && return
       end
+      tar_extract.close
     rescue SyntaxError => e
       flash[:error] = e.message
+      render(action: "new") && return
+    rescue StandardError => e
+      flash[:error] = "Read error"
+      render(action: "new") && return
     end
   end
 end
 
-# FP guard: nested respond_to inside an if branch should not see sibling format render
+# FP guard: flash in if inside multi-stmt begin body — rescue has render but
+# RuboCop finds the if ancestor first, not rescue (root cause 23).
+# Multi-stmt begin body wraps stmts in Parser's begin node, so if.right_siblings
+# are the remaining begin body stmts (empty here), not the resbody nodes.
 class SpentTimeController < ApplicationController
-  def create
-    if save_result
-      flash[:notice] = l("time_entry_added_notice")
-      logger.info("Everything went fine rendering report result")
-      respond_to do |format|
-        if current_date > to_date
-          to_date
-        elsif current_date < from_date
-          from_date
+  def create_entry
+    begin
+      setup_user
+      if save_result
+        flash[:notice] = l("time_entry_added_notice")
+        respond_to do |format|
+          format.js
+          return
         end
-        format.html { redirect_to report_path }
-        format.json { render json: time_entry, status: :created }
+      end
+    rescue Exception => exception
+      respond_to do |format|
+        flash[:error] = exception.message
+        format.js { render 'create_entry_error' }
       end
     end
   end


### PR DESCRIPTION
## Summary
- Fixes `check_begin_body_with_rescue` passing rescue clause nodes as outer context to nested if/unless, causing render in rescue bodies to be visible (FP=2)
- In RuboCop, `each_ancestor(:if, :rescue)` finds if/unless before rescue — their right_siblings are the remaining begin body stmts, not rescue content
- Single-stmt begin bodies are handled differently: Parser AST makes the node a direct child of rescue, so resbody IS in right_siblings

## Test plan
- [x] Unit tests pass (offense + no_offense fixtures)
- [x] `cargo clippy --release -- -D warnings` clean
- [x] Full test suite passes (129 tests)
- [x] Verified FP=0 on `autolab__Autolab` `courses_controller.rb`
- [x] Verified FP=0 on `eyp__redmine_spent_time` `spent_time_controller.rb`

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)