### PR TITLE
Persist agent findings on cleanup-failure

### DIFF
--- a/scripts/workflows/cop_fix_lifecycle.py
+++ b/scripts/workflows/cop_fix_lifecycle.py
@@ -1338,6 +1338,15 @@ def cmd_cleanup_failure(args: list[str]) -> int:
                 f"- Run: {opts.run_url}\n\n"
                 f"Review the failed workflow run for details.\n"
             )
+        # Include agent findings so future retry runs see what was tried.
+        findings = _read_agent_findings()
+        if findings:
+            body += (
+                "\n<details>\n"
+                "<summary>Agent findings (what was tried)</summary>\n\n"
+                f"```\n{findings}\n```\n"
+                "</details>\n"
+            )
         write_and_read(claim_body, body)
         _warn_best_effort_failure(
             f"Comment on issue #{opts.issue_number}",

--- a/src/cop/layout/multiline_method_call_indentation.rs
+++ b/src/cop/layout/multiline_method_call_indentation.rs
@@ -52,6 +52,36 @@ use crate::parse::source::SourceFile;
 ///   with keyword expressions and block chains.
 /// - Some complex patterns involving operation RHS (`a + b\n    .c`) may not
 ///   be fully handled.
+///
+/// ## Corpus investigation (2026-04-01, run 23848128960, timed out)
+///
+/// Baseline: 32,658 matches, 3,962 FP, 7,992 FN (73.2% match rate).
+///
+/// Attempted fix with three major changes:
+/// 1. **Aligned style fallback** — introduced `AlignedExpectation::Base` vs
+///    `Fallback`. When no semantic alignment base exists (no dot above, no
+///    block chain, no syntactic anchor), fall back to normal indentation
+///    (`lhs_indent + width`) instead of accepting any column.
+/// 2. **Receiver-chain continuation dot tightening** — added
+///    `continuation_anchor_is_valid()` to only reuse an earlier continuation
+///    dot when the chain's first continuation call is itself correctly anchored.
+/// 3. **Assignment RHS across lines** — added `starts_rhs_after_assignment_line()`
+///    to handle `resources =\n  Constant\n    .new(...)` where `=` is on a
+///    previous line.
+///
+/// Also added ancestor tracking (`Vec<Node>`) to ChainVisitor for
+/// `find_dot_right_above()` and `find_logical_operator_alignment()`.
+///
+/// Result: last corpus check showed +623 FP (worse), -437 FP (better),
+/// -4 FN (better). Net +186 FP regression. The fallback indentation was
+/// firing too aggressively — patterns like standalone method calls at column 0
+/// (e.g., `.where(...)` after a long expression) were being flagged. The
+/// `continuation_anchor_is_valid()` check was also too strict, rejecting
+/// valid continuation dot alignments in some cases.
+///
+/// An earlier intermediate state showed +154 worse / -321 better (net -167,
+/// close to positive), suggesting the approach can work with narrower
+/// fallback scoping.
 pub struct MultilineMethodCallIndentation;
 
 impl Cop for MultilineMethodCallIndentation {

--- a/src/cop/layout/space_around_operators.rs
+++ b/src/cop/layout/space_around_operators.rs
@@ -45,6 +45,31 @@ use ruby_prism::Visit;
 /// for consecutive simple `=` assignments at the same indentation level, not
 /// for `==`, `!=`, `=>`, etc.), and ensure code-map checks don't suppress
 /// operators that happen to be adjacent to string literals.
+///
+/// ## Corpus investigation (2026-04-01, run 23848125495, timed out)
+///
+/// Attempted fix: collect plain assignment `=` offsets from Prism
+/// (LocalVariableWriteNode, InstanceVariableWriteNode, ClassVariableWriteNode,
+/// GlobalVariableWriteNode, MultiWriteNode) and apply the assignment-specific
+/// leading-space rule only to those offsets, keeping setter/index writes and
+/// extra trailing spaces unchanged. Also added ternary `?`/`:` detection via
+/// `visit_if_node` (checking `if_keyword_loc().is_none()` for ternary form).
+///
+/// Result: removed 21 FPs but introduced 16 new FPs (all in ruby__tk repo).
+/// Net -5 FP with tests still failing at timeout. The alignment-block-neighbor
+/// detection (`assignment_block_neighbor_line`) was too loose — it walked up/down
+/// from the current line looking for lines at the same indentation with
+/// assignment operators, but didn't correctly handle cases where a later `==` on
+/// the same line aligned with the `=`, causing real offenses to be suppressed.
+///
+/// Key findings:
+/// - RuboCop accepts extra leading spaces before plain `=` when the write is
+///   standalone or part of a same-indentation assignment group whose `=` tokens
+///   align with the *first* alignment operator on neighbor lines.
+/// - The `first_alignment_operator_end_col()` approach is correct for finding
+///   the alignment anchor, but the neighbor-line search needs tighter scoping.
+/// - Ternary `?`/`:` via `visit_if_node` works but was not the cause of test
+///   failures.
 pub struct SpaceAroundOperators;
 
 /// Collect byte offsets of `=` signs that are part of parameter defaults,

--- a/tests/python/workflows/test_cop_fix_lifecycle.py
+++ b/tests/python/workflows/test_cop_fix_lifecycle.py
@@ -312,7 +312,10 @@ def test_cleanup_failure_closes_pr_then_deletes_branch_and_requeues_issue(tmp_pa
     claim_body = tmp_path / "context" / "claim-body.md"
     claim_body.parent.mkdir(parents=True, exist_ok=True)
 
-    env_patch = {"CLAIM_BODY_FILE": str(claim_body)}
+    env_patch = {
+        "CLAIM_BODY_FILE": str(claim_body),
+        "AGENT_RESULT_FILE": str(tmp_path / "agent" / "agent-result.json"),
+    }
     calls = []
 
     def fake_run_ok(cmd, **kwargs):
@@ -358,11 +361,57 @@ def test_cleanup_failure_closes_pr_then_deletes_branch_and_requeues_issue(tmp_pa
     assert "The draft PR was closed automatically." in claim_body.read_text()
 
 
+def test_cleanup_failure_includes_agent_findings_when_result_file_exists(tmp_path):
+    claim_body = tmp_path / "context" / "claim-body.md"
+    claim_body.parent.mkdir(parents=True, exist_ok=True)
+    result_file = tmp_path / "agent" / "agent-result.json"
+    result_file.parent.mkdir(parents=True, exist_ok=True)
+    result_file.write_text(json.dumps({"result": "Tried collecting assignment offsets from Prism.\nNet -5 FP but 16 new FPs in ruby__tk."}))
+
+    env_patch = {
+        "CLAIM_BODY_FILE": str(claim_body),
+        "AGENT_RESULT_FILE": str(result_file),
+    }
+    calls = []
+
+    def fake_run_ok(cmd, **kwargs):
+        del kwargs
+        calls.append(cmd)
+        if cmd[:4] == ["gh", "pr", "view", "https://github.com/6/nitrocop/pull/715"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout='{"headRefName":"fix/style-if_unless_modifier-23699434606"}', stderr="",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    with (
+        patch.dict(os.environ, env_patch),
+        patch.object(cop_fix_lifecycle, "_run_ok", side_effect=fake_run_ok),
+    ):
+        result = cop_fix_lifecycle.cmd_cleanup_failure([
+            "--cop", "Style/IfUnlessModifier",
+            "--pr-url", "https://github.com/6/nitrocop/pull/715",
+            "--issue-number", "376",
+            "--repo", "6/nitrocop",
+            "--backend-label", "claude-oauth / hard",
+            "--model-label", "Claude Opus 4.6 (OAuth, high)",
+            "--mode", "fix",
+            "--run-url", "https://github.com/6/nitrocop/actions/runs/23699434606",
+        ])
+
+    assert result == 0
+    body_text = claim_body.read_text()
+    assert "Agent findings (what was tried)" in body_text
+    assert "assignment offsets from Prism" in body_text
+
+
 def test_cleanup_failure_warns_and_keeps_issue_state_when_pr_close_fails(tmp_path):
     claim_body = tmp_path / "context" / "claim-body.md"
     claim_body.parent.mkdir(parents=True, exist_ok=True)
 
-    env_patch = {"CLAIM_BODY_FILE": str(claim_body)}
+    env_patch = {
+        "CLAIM_BODY_FILE": str(claim_body),
+        "AGENT_RESULT_FILE": str(tmp_path / "agent" / "agent-result.json"),
+    }
     calls = []
     warnings = []
 


### PR DESCRIPTION
## Summary

- **Bug fix:** `cmd_cleanup_failure()` now extracts and posts agent findings to the tracker issue, matching what `_close_pr_no_changes()` already does. This closes the feedback loop so timed-out/failed runs feed investigation context into `prior-attempts` for retry runs.
- **Doc comments:** Recovered investigation findings from two timed-out agent runs ([#1144](https://github.com/6/nitrocop/pull/1144), [#1146](https://github.com/6/nitrocop/pull/1146)) and added them as `///` doc comments on the `SpaceAroundOperators` and `MultilineMethodCallIndentation` cop structs.

### Why this matters

Without the fix, agents that time out lose all investigation work — the findings stay buried in CI artifacts. The next retry agent starts from scratch and often repeats the exact same failed approach. With this fix, the `_collect_nofix_findings()` scraper in `dispatch_cops.py` will pick up findings from failed runs via the standard "Agent findings" heading.

## Test plan

- [x] Existing `cleanup_failure` tests updated with `AGENT_RESULT_FILE` env var
- [x] New test `test_cleanup_failure_includes_agent_findings_when_result_file_exists` verifies findings appear in issue comment
- [x] `uv run pytest tests/python/ --tb=short` — 377 passed
- [x] `cargo test --lib -- cop::layout::space_around_operators` — 3 passed
- [x] `cargo test --lib -- cop::layout::multiline_method_call_indentation` — 9 passed
- [x] `uv run ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)