### PR TITLE
Extract shared string escape helpers from 4 cops

### DIFF
--- a/src/cop/style/quoted_symbols.rs
+++ b/src/cop/style/quoted_symbols.rs
@@ -1,4 +1,5 @@
 use crate::cop::node_type::SYMBOL_NODE;
+use crate::cop::util;
 use crate::cop::{Cop, CopConfig};
 use crate::diagnostic::Diagnostic;
 use crate::parse::source::SourceFile;
@@ -91,7 +92,7 @@ impl Cop for QuotedSymbols {
                 &src_bytes[1..]
             };
 
-            if prefer_single && !double_quotes_required(string_literal_src) {
+            if prefer_single && !util::double_quotes_required(string_literal_src) {
                 let (line, column) = source.offset_to_line_col(loc.start_offset());
                 diagnostics.push(self.diagnostic(
                     source,
@@ -130,29 +131,6 @@ impl Cop for QuotedSymbols {
             }
         }
     }
-}
-
-fn double_quotes_required(src: &[u8]) -> bool {
-    let mut backslash_run = 0usize;
-
-    for &byte in src {
-        if byte == b'\'' {
-            return true;
-        }
-
-        if byte == b'\\' {
-            backslash_run += 1;
-            continue;
-        }
-
-        if backslash_run % 2 == 1 && byte != b'\\' && byte != b'"' {
-            return true;
-        }
-
-        backslash_run = 0;
-    }
-
-    false
 }
 
 #[cfg(test)]

--- a/src/cop/style/redundant_percent_q.rs
+++ b/src/cop/style/redundant_percent_q.rs
@@ -1,4 +1,5 @@
 use crate::cop::node_type::{INTERPOLATED_STRING_NODE, STRING_NODE};
+use crate::cop::util;
 use crate::cop::{Cop, CopConfig};
 use crate::diagnostic::Diagnostic;
 use crate::parse::source::SourceFile;
@@ -128,7 +129,7 @@ fn acceptable_static_percent_capital_q(source: &[u8]) -> bool {
     // RuboCop only applies double_quotes_required? for `str` (single-line) nodes.
     // The Ruby parser represents multiline strings as `dstr` where str_type? is false.
     // Prism always uses StringNode for static strings, so check for newlines to match.
-    source.contains(&b'"') && !source.contains(&b'\n') && double_quotes_required(source)
+    source.contains(&b'"') && !source.contains(&b'\n') && util::double_quotes_required(source)
 }
 
 fn acceptable_dynamic_percent_capital_q(source: &[u8]) -> bool {
@@ -167,33 +168,6 @@ fn contains_interpolation_pattern(source: &[u8]) -> bool {
                 .position(|&b| b == b'}')
                 .is_some_and(|offset| offset > 0)
     })
-}
-
-/// Match RuboCop's `double_quotes_required?` helper on the full node source.
-fn double_quotes_required(source: &[u8]) -> bool {
-    let mut i = 0;
-
-    while i < source.len() {
-        match source[i] {
-            b'\'' => return true,
-            b'\\' => {
-                let run_start = i;
-                while i < source.len() && source[i] == b'\\' {
-                    i += 1;
-                }
-
-                let run_len = i - run_start;
-                let next = source.get(i).copied();
-
-                if run_len % 2 == 1 && !matches!(next, Some(b'\\' | b'"')) {
-                    return true;
-                }
-            }
-            _ => i += 1,
-        }
-    }
-
-    false
 }
 
 fn path_has_hidden_directory(path: &Path) -> bool {

--- a/src/cop/style/string_literals.rs
+++ b/src/cop/style/string_literals.rs
@@ -1,5 +1,6 @@
 use ruby_prism::Visit;
 
+use crate::cop::util;
 use crate::cop::{Cop, CopConfig};
 use crate::diagnostic::Diagnostic;
 use crate::parse::source::SourceFile;
@@ -139,7 +140,7 @@ impl<'pr> Visit<'pr> for StringLiteralsVisitor<'_> {
                     // Check if single quotes can be used:
                     // - No single quotes in content
                     // - No escape sequences (no backslash in content)
-                    if !content.contains(&b'\'') && !needs_double_quotes(content) {
+                    if !util::double_quotes_required(content) {
                         let (line, column) = self.source.offset_to_line_col(opening.start_offset());
                         self.diagnostics.push(self.cop.diagnostic(self.source, line, column, "Prefer single-quoted strings when you don't need string interpolation or special symbols.".to_string()));
                     }
@@ -213,29 +214,6 @@ fn has_meaningful_backslash_escape(content: &[u8]) -> bool {
 }
 
 /// Check if a double-quoted string's raw source content contains escape
-/// sequences that require double quotes, matching RuboCop's
-/// `double_quotes_required?` logic. A backslash followed by any character
-/// that is NOT `\` or `"` is considered to require double quotes — this is
-/// conservative but prevents visual changes to escape-like sequences such
-/// as `\g`, `\p`, etc.
-fn needs_double_quotes(content: &[u8]) -> bool {
-    let mut i = 0;
-    while i < content.len() {
-        if content[i] == b'\\' && i + 1 < content.len() {
-            let next = content[i + 1];
-            // \\ and \" are safe to convert (they become literal chars in single quotes too)
-            if next == b'\\' || next == b'"' {
-                i += 2;
-                continue;
-            }
-            // Any other \X pattern requires double quotes
-            return true;
-        }
-        i += 1;
-    }
-    false
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cop/style/string_literals_in_interpolation.rs
+++ b/src/cop/style/string_literals_in_interpolation.rs
@@ -1,5 +1,6 @@
 use ruby_prism::Visit;
 
+use crate::cop::util;
 use crate::cop::{Cop, CopConfig};
 use crate::diagnostic::Diagnostic;
 use crate::parse::source::SourceFile;
@@ -126,7 +127,7 @@ impl<'pr> Visit<'pr> for InterpStringVisitor<'_> {
                 if open_bytes == b"\"" {
                     // Check if it needs double quotes (has escape sequences)
                     let content = node.content_loc().as_slice();
-                    if !needs_double_quotes(content) {
+                    if !util::double_quotes_required(content) {
                         let loc = node.location();
                         let (line, column) = self.source.offset_to_line_col(loc.start_offset());
                         self.diagnostics.push(self.cop.diagnostic(
@@ -153,35 +154,6 @@ impl<'pr> Visit<'pr> for InterpStringVisitor<'_> {
             _ => {}
         }
     }
-}
-
-fn needs_double_quotes(content: &[u8]) -> bool {
-    let mut i = 0;
-    while i < content.len() {
-        // If the content contains a bare single quote, it can't use single-quoted style
-        if content[i] == b'\'' {
-            return true;
-        }
-        if content[i] == b'\\' && i + 1 < content.len() {
-            match content[i + 1] {
-                // \\ and \" are safe to convert to single quotes:
-                // \\ is valid in single-quoted strings ('\\' → \)
-                // \" is only needed in double quotes; single quotes write " directly
-                b'\\' | b'"' => {
-                    i += 2;
-                    continue;
-                }
-                // Everything else requires double quotes:
-                // - Recognized escapes (\n, \t, etc.) only work in double quotes
-                // - \' hides a literal single quote
-                // - Unrecognized escapes (\., \/, \#) produce just the char in
-                //   double quotes but \char (two chars) in single quotes
-                _ => return true,
-            }
-        }
-        i += 1;
-    }
-    false
 }
 
 #[cfg(test)]

--- a/src/cop/util.rs
+++ b/src/cop/util.rs
@@ -1088,6 +1088,48 @@ pub fn full_constant_path<'a>(source: &'a SourceFile, node: &ruby_prism::Node<'_
     &source.as_bytes()[loc.start_offset()..loc.end_offset()]
 }
 
+// ── String escape helpers ─────────────────────────────────────────────
+
+/// Check if string content contains escape sequences that require double quotes.
+///
+/// Returns true if the content has `\X` where X is anything other than `\` or `"`.
+/// Those two escapes (`\\`, `\"`) are representable in single-quoted strings, but
+/// all others (`\n`, `\t`, `\#`, etc.) require double quotes.
+///
+/// Handles consecutive backslashes correctly: in `\\\\n`, there are 4 backslashes
+/// (2 pairs of `\\`) followed by `n`, which does NOT require double quotes.
+pub fn has_non_trivial_escape(content: &[u8]) -> bool {
+    let mut i = 0;
+    while i < content.len() {
+        if content[i] == b'\\' {
+            let run_start = i;
+            while i < content.len() && content[i] == b'\\' {
+                i += 1;
+            }
+            let run_len = i - run_start;
+            let next = content.get(i).copied();
+            // Odd number of backslashes means the last one escapes the next char.
+            // Only \\ and \" are safe for single quotes; anything else needs double.
+            if run_len % 2 == 1 && !matches!(next, Some(b'\\' | b'"')) {
+                return true;
+            }
+        } else {
+            i += 1;
+        }
+    }
+    false
+}
+
+/// Check if string content requires double-quoted representation.
+///
+/// Returns true if the content contains a bare single quote (`'`) or escape
+/// sequences that only work in double-quoted strings. This is the combined
+/// check used by quoted_symbols, string_literals_in_interpolation, and
+/// redundant_percent_q cops.
+pub fn double_quotes_required(content: &[u8]) -> bool {
+    content.contains(&b'\'') || has_non_trivial_escape(content)
+}
+
 // ── Shared node helpers ────────────────────────────────────────────────
 
 /// Unwrap parentheses from a node, returning the inner expression.
@@ -1512,6 +1554,37 @@ mod tests {
         // Hash rocket (not assignment): `x => if ...`
         let src = SourceFile::from_bytes("test.rb", b"x => if foo\n  bar\nend\n".to_vec());
         assert_eq!(assignment_context_base_col(&src, 5), None);
+    }
+
+    // ── string escape helper tests ─────────────────────────────────────
+
+    #[test]
+    fn has_non_trivial_escape_basic() {
+        assert!(has_non_trivial_escape(b"hello\\nworld"));
+        assert!(has_non_trivial_escape(b"\\t"));
+        assert!(!has_non_trivial_escape(b"hello"));
+        assert!(!has_non_trivial_escape(b"hello\\\\world")); // \\\\ = two literal backslashes
+        assert!(!has_non_trivial_escape(b"hello\\\"world")); // \\\" = escaped quote
+    }
+
+    #[test]
+    fn has_non_trivial_escape_consecutive_backslashes() {
+        // 3 backslashes + n: odd count means last one escapes n → needs double quotes
+        assert!(has_non_trivial_escape(b"\\\\\\n"));
+        // 4 backslashes + n: even count means all are paired, n is literal
+        assert!(!has_non_trivial_escape(b"\\\\\\\\n"));
+    }
+
+    #[test]
+    fn double_quotes_required_bare_quote() {
+        assert!(double_quotes_required(b"it's"));
+        assert!(!double_quotes_required(b"hello"));
+    }
+
+    #[test]
+    fn double_quotes_required_escapes() {
+        assert!(double_quotes_required(b"hello\\nworld"));
+        assert!(!double_quotes_required(b"hello\\\\world"));
     }
 
     // ── unwrap_parentheses tests ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- Extract `has_non_trivial_escape` and `double_quotes_required` into `util.rs`
- Deduplicate from: string_literals, string_literals_in_interpolation, quoted_symbols, redundant_percent_q
- Uses robust run-length based backslash counting (handles consecutive backslashes correctly)
- 4 unit tests covering basic escapes, consecutive backslashes, and bare quotes

## Test plan
- [x] `cargo clippy --release -- -D warnings` clean
- [x] `cargo test --release` — all tests pass
- [x] All existing fixture tests preserved and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)