### PR TITLE
Extract shared MultilineLiteralBraceLayout helper from 4 cops

### DIFF
--- a/scripts/dispatch_cops.py
+++ b/scripts/dispatch_cops.py
@@ -112,6 +112,16 @@ HASH_TRANSFORM_CONSUMERS = {
     "Style/HashTransformValues",
 }
 
+# Cops that consume the shared MultilineLiteralBraceLayout helper. Changes to
+# src/cop/layout/multiline_literal_brace_layout.rs should trigger corpus checks
+# for all four.
+MULTILINE_BRACE_LAYOUT_CONSUMERS = {
+    "Layout/MultilineArrayBraceLayout",
+    "Layout/MultilineHashBraceLayout",
+    "Layout/MultilineMethodCallBraceLayout",
+    "Layout/MultilineMethodDefinitionBraceLayout",
+}
+
 # Department PascalCase → snake_case directory name in src/cop/ and tests/fixtures/
 # Only needed for departments where pascal_to_snake() gives the wrong result
 DEPT_TO_SRC_DIR = {
@@ -1565,6 +1575,9 @@ def detect_cops(base: str, head: str) -> list[str]:
             elif name == "hash_transform_method":
                 # Shared helper changes affect both transform cops
                 cops.update(HASH_TRANSFORM_CONSUMERS)
+            elif name == "multiline_literal_brace_layout":
+                # Shared helper changes affect all four brace layout cops
+                cops.update(MULTILINE_BRACE_LAYOUT_CONSUMERS)
             elif name not in {"mod", "node_type"}:
                 cops.add(f"{dept_snake_to_pascal(dept)}/{snake_to_pascal(name)}")
             continue

--- a/src/cop/layout/mod.rs
+++ b/src/cop/layout/mod.rs
@@ -60,6 +60,7 @@ pub mod multiline_assignment_layout;
 pub mod multiline_block_layout;
 pub mod multiline_hash_brace_layout;
 pub mod multiline_hash_key_line_breaks;
+pub mod multiline_literal_brace_layout;
 pub mod multiline_method_argument_line_breaks;
 pub mod multiline_method_call_brace_layout;
 pub mod multiline_method_call_indentation;

--- a/src/cop/layout/multiline_array_brace_layout.rs
+++ b/src/cop/layout/multiline_array_brace_layout.rs
@@ -3,6 +3,8 @@ use crate::cop::{Cop, CopConfig};
 use crate::diagnostic::Diagnostic;
 use crate::parse::source::SourceFile;
 
+use super::multiline_literal_brace_layout::{self, ARRAY_BRACE, BracePositions};
+
 /// Layout/MultilineArrayBraceLayout
 ///
 /// ## Investigation findings
@@ -66,102 +68,33 @@ impl Cop for MultilineArrayBraceLayout {
         // Skip arrays where the last element contains a heredoc — the heredoc
         // body forces the closing brace placement and adjusting it would
         // produce invalid code.
-        if contains_heredoc(&last_elem) {
+        if multiline_literal_brace_layout::contains_heredoc(&last_elem) {
             return;
         }
 
         let (open_line, _) = source.offset_to_line_col(opening.start_offset());
         let (close_line, close_col) = source.offset_to_line_col(closing.start_offset());
 
-        // Get first and last element lines
         let first_elem = elements.iter().next().unwrap();
         let (first_elem_line, _) = source.offset_to_line_col(first_elem.location().start_offset());
         let (last_elem_line, _) =
             source.offset_to_line_col(last_elem.location().end_offset().saturating_sub(1));
 
-        // Only check multiline arrays
-        if open_line == close_line {
-            return;
-        }
-
-        let open_same_as_first = open_line == first_elem_line;
-        let close_same_as_last = close_line == last_elem_line;
-
-        match enforced_style {
-            "symmetrical" => {
-                // Opening and closing should be symmetric
-                if open_same_as_first && !close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "The closing array brace must be on the same line as the last array element when the opening brace is on the same line as the first array element.".to_string(),
-                    ));
-                }
-                if !open_same_as_first && close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "The closing array brace must be on the line after the last array element when the opening brace is on a separate line from the first array element.".to_string(),
-                    ));
-                }
-            }
-            "new_line" => {
-                if close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "The closing array brace must be on the line after the last array element."
-                            .to_string(),
-                    ));
-                }
-            }
-            "same_line" => {
-                if !close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "The closing array brace must be on the same line as the last array element."
-                            .to_string(),
-                    ));
-                }
-            }
-            _ => {}
-        }
+        multiline_literal_brace_layout::check_brace_layout(
+            self,
+            source,
+            enforced_style,
+            &ARRAY_BRACE,
+            &BracePositions {
+                open_line,
+                close_line,
+                close_col,
+                first_elem_line,
+                last_elem_line,
+            },
+            diagnostics,
+        );
     }
-}
-
-/// Check if an array element node contains a heredoc string.
-/// Walks into method call receivers/arguments.
-fn contains_heredoc(node: &ruby_prism::Node<'_>) -> bool {
-    if let Some(s) = node.as_interpolated_string_node() {
-        if let Some(open) = s.opening_loc() {
-            return open.as_slice().starts_with(b"<<");
-        }
-    }
-    if let Some(s) = node.as_string_node() {
-        if let Some(open) = s.opening_loc() {
-            return open.as_slice().starts_with(b"<<");
-        }
-    }
-    if let Some(call) = node.as_call_node() {
-        if let Some(recv) = call.receiver() {
-            if contains_heredoc(&recv) {
-                return true;
-            }
-        }
-        if let Some(args) = call.arguments() {
-            for arg in args.arguments().iter() {
-                if contains_heredoc(&arg) {
-                    return true;
-                }
-            }
-        }
-    }
-    false
 }
 
 #[cfg(test)]

--- a/src/cop/layout/multiline_hash_brace_layout.rs
+++ b/src/cop/layout/multiline_hash_brace_layout.rs
@@ -3,6 +3,8 @@ use crate::cop::{Cop, CopConfig};
 use crate::diagnostic::Diagnostic;
 use crate::parse::source::SourceFile;
 
+use super::multiline_literal_brace_layout::{self, BracePositions, HASH_BRACE};
+
 /// Layout/MultilineHashBraceLayout
 ///
 /// ## Corpus investigation (2026-03-10)
@@ -68,108 +70,33 @@ impl Cop for MultilineHashBraceLayout {
 
         // Only the last element can force the closing brace to move because of
         // its heredoc terminator. Earlier heredocs do not exempt the hash.
-        if contains_heredoc(&last_elem) {
+        if multiline_literal_brace_layout::contains_heredoc(&last_elem) {
             return;
         }
 
         let (open_line, _) = source.offset_to_line_col(opening.start_offset());
         let (close_line, close_col) = source.offset_to_line_col(closing.start_offset());
 
-        // Get first and last element lines
         let first_elem = elements.iter().next().unwrap();
         let (first_elem_line, _) = source.offset_to_line_col(first_elem.location().start_offset());
         let (last_elem_line, _) =
             source.offset_to_line_col(last_elem.location().end_offset().saturating_sub(1));
 
-        // Only check multiline hashes
-        if open_line == close_line {
-            return;
-        }
-
-        let open_same_as_first = open_line == first_elem_line;
-        let close_same_as_last = close_line == last_elem_line;
-
-        match enforced_style {
-            "symmetrical" => {
-                if open_same_as_first && !close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "Closing hash brace must be on the same line as the last hash element when opening brace is on the same line as the first hash element.".to_string(),
-                    ));
-                }
-                if !open_same_as_first && close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "Closing hash brace must be on the line after the last hash element when opening brace is on a separate line from the first hash element.".to_string(),
-                    ));
-                }
-            }
-            "new_line" => {
-                if close_same_as_last {
-                    diagnostics.push(
-                        self.diagnostic(
-                            source,
-                            close_line,
-                            close_col,
-                            "Closing hash brace must be on the line after the last hash element."
-                                .to_string(),
-                        ),
-                    );
-                }
-            }
-            "same_line" => {
-                if !close_same_as_last {
-                    diagnostics.push(
-                        self.diagnostic(
-                            source,
-                            close_line,
-                            close_col,
-                            "Closing hash brace must be on the same line as the last hash element."
-                                .to_string(),
-                        ),
-                    );
-                }
-            }
-            _ => {}
-        }
+        multiline_literal_brace_layout::check_brace_layout(
+            self,
+            source,
+            enforced_style,
+            &HASH_BRACE,
+            &BracePositions {
+                open_line,
+                close_line,
+                close_col,
+                first_elem_line,
+                last_elem_line,
+            },
+            diagnostics,
+        );
     }
-}
-
-/// Check if a hash element node contains a heredoc string.
-/// Walks into AssocNode values and method call receivers/arguments.
-fn contains_heredoc(node: &ruby_prism::Node<'_>) -> bool {
-    if let Some(s) = node.as_interpolated_string_node() {
-        if let Some(open) = s.opening_loc() {
-            return open.as_slice().starts_with(b"<<");
-        }
-    }
-    if let Some(s) = node.as_string_node() {
-        if let Some(open) = s.opening_loc() {
-            return open.as_slice().starts_with(b"<<");
-        }
-    }
-    if let Some(call) = node.as_call_node() {
-        if let Some(recv) = call.receiver() {
-            if contains_heredoc(&recv) {
-                return true;
-            }
-        }
-        if let Some(args) = call.arguments() {
-            for arg in args.arguments().iter() {
-                if contains_heredoc(&arg) {
-                    return true;
-                }
-            }
-        }
-    }
-    if let Some(assoc) = node.as_assoc_node() {
-        return contains_heredoc(&assoc.value());
-    }
-    false
 }
 
 #[cfg(test)]

--- a/src/cop/layout/multiline_literal_brace_layout.rs
+++ b/src/cop/layout/multiline_literal_brace_layout.rs
@@ -1,0 +1,249 @@
+//! Shared infrastructure for the four `MultilineBraceLayout` cops.
+//!
+//! Mirrors RuboCop's `MultilineLiteralBraceLayout` mixin. All four cops
+//! enforce the same symmetrical / new_line / same_line style on the closing
+//! brace relative to the opening brace and the first/last element. The only
+//! differences are:
+//! - which AST node supplies the opening/closing locations and elements,
+//! - the noun used in diagnostic messages ("array", "hash", etc.), and
+//! - how heredocs are detected (simple recursive walk vs. visitor-based).
+
+use crate::cop::Cop;
+use crate::diagnostic::Diagnostic;
+use crate::parse::source::SourceFile;
+
+/// Describes the kind of brace construct, used to generate cop-specific
+/// diagnostic messages that exactly match RuboCop's wording.
+pub struct BraceKind {
+    /// Phrase for the closing brace, e.g. "The closing array brace" or
+    /// "Closing hash brace".
+    pub closing_phrase: &'static str,
+    /// Phrase for the opening brace, e.g. "the opening brace" or
+    /// "opening brace".
+    pub opening_phrase: &'static str,
+    /// Noun for the elements, e.g. "array element" or "argument".
+    pub element_noun: &'static str,
+}
+
+pub const ARRAY_BRACE: BraceKind = BraceKind {
+    closing_phrase: "The closing array brace",
+    opening_phrase: "the opening brace",
+    element_noun: "array element",
+};
+
+pub const HASH_BRACE: BraceKind = BraceKind {
+    closing_phrase: "Closing hash brace",
+    opening_phrase: "opening brace",
+    element_noun: "hash element",
+};
+
+pub const METHOD_CALL_BRACE: BraceKind = BraceKind {
+    closing_phrase: "Closing method call brace",
+    opening_phrase: "opening brace",
+    element_noun: "argument",
+};
+
+pub const METHOD_DEFINITION_BRACE: BraceKind = BraceKind {
+    closing_phrase: "Closing method definition brace",
+    opening_phrase: "opening brace",
+    element_noun: "parameter",
+};
+
+/// The computed positions extracted by each cop before calling the shared
+/// style check.
+pub struct BracePositions {
+    pub open_line: usize,
+    pub close_line: usize,
+    pub close_col: usize,
+    pub first_elem_line: usize,
+    pub last_elem_line: usize,
+}
+
+/// Shared style enforcement for all four multiline brace layout cops.
+///
+/// Returns early (no diagnostic) when the construct is single-line.
+pub fn check_brace_layout(
+    cop: &dyn Cop,
+    source: &SourceFile,
+    enforced_style: &str,
+    kind: &BraceKind,
+    pos: &BracePositions,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    // Only check multiline constructs
+    if pos.open_line == pos.close_line {
+        return;
+    }
+
+    let open_same_as_first = pos.open_line == pos.first_elem_line;
+    let close_same_as_last = pos.close_line == pos.last_elem_line;
+
+    let closing = kind.closing_phrase;
+    let element = kind.element_noun;
+    let opening = kind.opening_phrase;
+
+    match enforced_style {
+        "symmetrical" => {
+            if open_same_as_first && !close_same_as_last {
+                diagnostics.push(cop.diagnostic(
+                    source,
+                    pos.close_line,
+                    pos.close_col,
+                    format!(
+                        "{closing} must be on the same line as the last {element} \
+                         when {opening} is on the same line as the first {element}."
+                    ),
+                ));
+            }
+            if !open_same_as_first && close_same_as_last {
+                diagnostics.push(cop.diagnostic(
+                    source,
+                    pos.close_line,
+                    pos.close_col,
+                    format!(
+                        "{closing} must be on the line after the last {element} \
+                         when {opening} is on a separate line from the first {element}."
+                    ),
+                ));
+            }
+        }
+        "new_line" => {
+            if close_same_as_last {
+                diagnostics.push(cop.diagnostic(
+                    source,
+                    pos.close_line,
+                    pos.close_col,
+                    format!("{closing} must be on the line after the last {element}."),
+                ));
+            }
+        }
+        "same_line" => {
+            if !close_same_as_last {
+                diagnostics.push(cop.diagnostic(
+                    source,
+                    pos.close_line,
+                    pos.close_col,
+                    format!("{closing} must be on the same line as the last {element}."),
+                ));
+            }
+        }
+        _ => {}
+    }
+}
+
+// ── Heredoc helpers ───────────────────────────────────────────────────
+
+/// Simple recursive heredoc check used by array and hash cops.
+///
+/// Returns `true` if *node* (or a nested call receiver/argument/assoc value)
+/// is a heredoc string (opening starts with `<<`).
+pub fn contains_heredoc(node: &ruby_prism::Node<'_>) -> bool {
+    if let Some(s) = node.as_interpolated_string_node() {
+        if let Some(open) = s.opening_loc() {
+            if open.as_slice().starts_with(b"<<") {
+                return true;
+            }
+        }
+    }
+    if let Some(s) = node.as_string_node() {
+        if let Some(open) = s.opening_loc() {
+            if open.as_slice().starts_with(b"<<") {
+                return true;
+            }
+        }
+    }
+    if let Some(call) = node.as_call_node() {
+        if let Some(recv) = call.receiver() {
+            if contains_heredoc(&recv) {
+                return true;
+            }
+        }
+        if let Some(args) = call.arguments() {
+            for arg in args.arguments().iter() {
+                if contains_heredoc(&arg) {
+                    return true;
+                }
+            }
+        }
+    }
+    if let Some(assoc) = node.as_assoc_node() {
+        return contains_heredoc(&assoc.value());
+    }
+    false
+}
+
+/// Visitor-based heredoc check used by the method-call cop.
+///
+/// Returns `true` when the node contains a heredoc whose closing delimiter
+/// ends on or after the last line of the node itself (i.e. the heredoc body
+/// forces the closing brace placement).
+pub fn last_line_heredoc(source: &SourceFile, node: &ruby_prism::Node<'_>) -> bool {
+    use ruby_prism::Visit;
+
+    struct LastLineHeredocDetector<'a> {
+        source: &'a SourceFile,
+        parent_last_line: usize,
+        found: bool,
+    }
+
+    impl LastLineHeredocDetector<'_> {
+        fn visit_heredoc<'pr>(
+            &mut self,
+            opening: Option<ruby_prism::Location<'pr>>,
+            closing: Option<ruby_prism::Location<'pr>>,
+        ) {
+            let Some(opening) = opening else {
+                return;
+            };
+            if self.found || !opening.as_slice().starts_with(b"<<") {
+                return;
+            }
+            let Some(closing) = closing else {
+                return;
+            };
+
+            let end_off = closing
+                .end_offset()
+                .saturating_sub(1)
+                .max(closing.start_offset());
+            let (closing_line, _) = self.source.offset_to_line_col(end_off);
+            if closing_line >= self.parent_last_line {
+                self.found = true;
+            }
+        }
+    }
+
+    impl<'pr> Visit<'pr> for LastLineHeredocDetector<'_> {
+        fn visit_string_node(&mut self, node: &ruby_prism::StringNode<'pr>) {
+            self.visit_heredoc(node.opening_loc(), node.closing_loc());
+            if !self.found {
+                ruby_prism::visit_string_node(self, node);
+            }
+        }
+
+        fn visit_interpolated_string_node(
+            &mut self,
+            node: &ruby_prism::InterpolatedStringNode<'pr>,
+        ) {
+            self.visit_heredoc(node.opening_loc(), node.closing_loc());
+            if !self.found {
+                ruby_prism::visit_interpolated_string_node(self, node);
+            }
+        }
+    }
+
+    let parent_last_line = node_last_line(source, node);
+    let mut detector = LastLineHeredocDetector {
+        source,
+        parent_last_line,
+        found: false,
+    };
+    detector.visit(node);
+    detector.found
+}
+
+fn node_last_line(source: &SourceFile, node: &ruby_prism::Node<'_>) -> usize {
+    let loc = node.location();
+    let end_off = loc.end_offset().saturating_sub(1).max(loc.start_offset());
+    source.offset_to_line_col(end_off).0
+}

--- a/src/cop/layout/multiline_method_call_brace_layout.rs
+++ b/src/cop/layout/multiline_method_call_brace_layout.rs
@@ -3,6 +3,8 @@ use crate::cop::{Cop, CopConfig};
 use crate::diagnostic::Diagnostic;
 use crate::parse::source::SourceFile;
 
+use super::multiline_literal_brace_layout::{self, BracePositions, METHOD_CALL_BRACE};
+
 /// ## Corpus investigation (2026-03-10)
 ///
 /// Corpus oracle reported FP=0, FN=3.
@@ -77,20 +79,14 @@ impl Cop for MultilineMethodCallBraceLayout {
         }
 
         let last_arg = arg_list.last().unwrap();
-        if last_line_heredoc(source, last_arg) {
+        if multiline_literal_brace_layout::last_line_heredoc(source, last_arg) {
             return;
         }
 
         let (open_line, _) = source.offset_to_line_col(opening.start_offset());
         let (close_line, close_col) = source.offset_to_line_col(closing.start_offset());
 
-        // Only check multiline calls (opening paren to closing paren)
-        if open_line == close_line {
-            return;
-        }
-
         let first_arg = &arg_list[0];
-
         let (first_arg_line, _) = source.offset_to_line_col(first_arg.location().start_offset());
 
         // Compute the effective end of the last argument. In Prism, `&block`
@@ -111,124 +107,21 @@ impl Cop for MultilineMethodCallBraceLayout {
         };
         let (last_arg_line, _) = source.offset_to_line_col(last_arg_end);
 
-        let open_same_as_first = open_line == first_arg_line;
-        let close_same_as_last = close_line == last_arg_line;
-
-        match enforced_style {
-            "symmetrical" => {
-                if open_same_as_first && !close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "Closing method call brace must be on the same line as the last argument when opening brace is on the same line as the first argument.".to_string(),
-                    ));
-                }
-                if !open_same_as_first && close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "Closing method call brace must be on the line after the last argument when opening brace is on a separate line from the first argument.".to_string(),
-                    ));
-                }
-            }
-            "new_line" => {
-                if close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "Closing method call brace must be on the line after the last argument."
-                            .to_string(),
-                    ));
-                }
-            }
-            "same_line" => {
-                if !close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "Closing method call brace must be on the same line as the last argument."
-                            .to_string(),
-                    ));
-                }
-            }
-            _ => {}
-        }
+        multiline_literal_brace_layout::check_brace_layout(
+            self,
+            source,
+            enforced_style,
+            &METHOD_CALL_BRACE,
+            &BracePositions {
+                open_line,
+                close_line,
+                close_col,
+                first_elem_line: first_arg_line,
+                last_elem_line: last_arg_line,
+            },
+            diagnostics,
+        );
     }
-}
-
-fn last_line_heredoc(source: &SourceFile, node: &ruby_prism::Node<'_>) -> bool {
-    use ruby_prism::Visit;
-
-    struct LastLineHeredocDetector<'a> {
-        source: &'a SourceFile,
-        parent_last_line: usize,
-        found: bool,
-    }
-
-    impl LastLineHeredocDetector<'_> {
-        fn visit_heredoc<'pr>(
-            &mut self,
-            opening: Option<ruby_prism::Location<'pr>>,
-            closing: Option<ruby_prism::Location<'pr>>,
-        ) {
-            let Some(opening) = opening else {
-                return;
-            };
-            if self.found || !opening.as_slice().starts_with(b"<<") {
-                return;
-            }
-            let Some(closing) = closing else {
-                return;
-            };
-
-            let end_off = closing
-                .end_offset()
-                .saturating_sub(1)
-                .max(closing.start_offset());
-            let (closing_line, _) = self.source.offset_to_line_col(end_off);
-            if closing_line >= self.parent_last_line {
-                self.found = true;
-            }
-        }
-    }
-
-    impl<'pr> Visit<'pr> for LastLineHeredocDetector<'_> {
-        fn visit_string_node(&mut self, node: &ruby_prism::StringNode<'pr>) {
-            self.visit_heredoc(node.opening_loc(), node.closing_loc());
-            if !self.found {
-                ruby_prism::visit_string_node(self, node);
-            }
-        }
-
-        fn visit_interpolated_string_node(
-            &mut self,
-            node: &ruby_prism::InterpolatedStringNode<'pr>,
-        ) {
-            self.visit_heredoc(node.opening_loc(), node.closing_loc());
-            if !self.found {
-                ruby_prism::visit_interpolated_string_node(self, node);
-            }
-        }
-    }
-
-    let parent_last_line = node_last_line(source, node);
-    let mut detector = LastLineHeredocDetector {
-        source,
-        parent_last_line,
-        found: false,
-    };
-    detector.visit(node);
-    detector.found
-}
-
-fn node_last_line(source: &SourceFile, node: &ruby_prism::Node<'_>) -> usize {
-    let loc = node.location();
-    let end_off = loc.end_offset().saturating_sub(1).max(loc.start_offset());
-    source.offset_to_line_col(end_off).0
 }
 
 #[cfg(test)]

--- a/src/cop/layout/multiline_method_definition_brace_layout.rs
+++ b/src/cop/layout/multiline_method_definition_brace_layout.rs
@@ -3,6 +3,8 @@ use crate::cop::{Cop, CopConfig};
 use crate::diagnostic::Diagnostic;
 use crate::parse::source::SourceFile;
 
+use super::multiline_literal_brace_layout::{self, BracePositions, METHOD_DEFINITION_BRACE};
+
 pub struct MultilineMethodDefinitionBraceLayout;
 
 impl Cop for MultilineMethodDefinitionBraceLayout {
@@ -47,11 +49,6 @@ impl Cop for MultilineMethodDefinitionBraceLayout {
 
         let (open_line, _) = source.offset_to_line_col(lparen_loc.start_offset());
         let (close_line, close_col) = source.offset_to_line_col(rparen_loc.start_offset());
-
-        // Only check multiline parameter lists
-        if open_line == close_line {
-            return;
-        }
 
         // Find the first and last parameter locations
         let mut first_offset: Option<usize> = None;
@@ -157,52 +154,20 @@ impl Cop for MultilineMethodDefinitionBraceLayout {
         let (first_param_line, _) = source.offset_to_line_col(first_off);
         let (last_param_line, _) = source.offset_to_line_col(last_end.saturating_sub(1));
 
-        let open_same_as_first = open_line == first_param_line;
-        let close_same_as_last = close_line == last_param_line;
-
-        match enforced_style {
-            "symmetrical" => {
-                if open_same_as_first && !close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "Closing method definition brace must be on the same line as the last parameter when opening brace is on the same line as the first parameter.".to_string(),
-                    ));
-                }
-                if !open_same_as_first && close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "Closing method definition brace must be on the line after the last parameter when opening brace is on a separate line from the first parameter.".to_string(),
-                    ));
-                }
-            }
-            "new_line" => {
-                if close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "Closing method definition brace must be on the line after the last parameter."
-                            .to_string(),
-                    ));
-                }
-            }
-            "same_line" => {
-                if !close_same_as_last {
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        close_line,
-                        close_col,
-                        "Closing method definition brace must be on the same line as the last parameter."
-                            .to_string(),
-                    ));
-                }
-            }
-            _ => {}
-        }
+        multiline_literal_brace_layout::check_brace_layout(
+            self,
+            source,
+            enforced_style,
+            &METHOD_DEFINITION_BRACE,
+            &BracePositions {
+                open_line,
+                close_line,
+                close_col,
+                first_elem_line: first_param_line,
+                last_elem_line: last_param_line,
+            },
+            diagnostics,
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- Extracts the shared brace layout style enforcement logic (symmetrical / new_line / same_line checking) and heredoc detection helpers from the four `MultilineBraceLayout` cops into a new `multiline_literal_brace_layout.rs` shared module, mirroring RuboCop's `MultilineLiteralBraceLayout` mixin.
- Each cop now delegates the style check to `check_brace_layout()`, keeping only its cop-specific AST extraction logic. Net reduction: -268 lines across the four cops.
- Adds `MULTILINE_BRACE_LAYOUT_CONSUMERS` dispatch group in `dispatch_cops.py` so changes to the shared module trigger corpus checks for all four cops.

## Test plan

- [x] All 10 existing fixture/unit tests for the four cops pass unchanged
- [x] Full lib test suite passes (4557 tests)
- [x] `cargo clippy --release -- -D warnings` clean
- [x] `uv run ruff check scripts/dispatch_cops.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)