### PR TITLE
Fix empty bot PRs: SKIP uncloned repos + full-file fallback for pre-diagnostic

### DIFF
--- a/scripts/dispatch_cops.py
+++ b/scripts/dispatch_cops.py
@@ -734,19 +734,21 @@ def _fetch_full_file(repo_url: str, sha: str, filepath: str) -> str | None:
 def _run_nitrocop_on_file(
     binary_path: Path, file_content: str, cop: str, filename: str = "test.rb",
 ) -> list[dict]:
-    """Run nitrocop on arbitrary file content, return offenses list."""
+    """Run nitrocop on arbitrary file content, return offenses list.
+
+    ``filename`` can be a relative path (e.g. ``spec/models/foo_spec.rb``);
+    intermediate directories are created so that cops with Include patterns
+    (like ``**/*_spec.rb`` or ``**/spec/**/*.rb``) can match.
+    """
     tmp_dir = tempfile.mkdtemp(prefix="nitrocop_diag_ff_")
     tmp_path = os.path.join(tmp_dir, filename)
+    os.makedirs(os.path.dirname(tmp_path), exist_ok=True)
     try:
         with open(tmp_path, "w") as f:
             f.write(file_content)
         return _run_nitrocop(binary_path, tmp_dir, cop, filename)
     finally:
-        try:
-            os.unlink(tmp_path)
-            os.rmdir(tmp_dir)
-        except OSError:
-            pass
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 BASELINE_CONFIG = PROJECT_ROOT / "bench" / "corpus" / "baseline_rubocop.yml"
@@ -870,72 +872,83 @@ def run_diagnostic(
                     )
 
                 # --- Full-file fallback ---
-                # When the snippet doesn't detect an FN, the extracted
-                # context may be too narrow (e.g. an `if` wrapping the
-                # entire class 60 lines above).  Fetch the real file and
-                # re-test to distinguish "snippet too narrow" from
-                # "genuine code bug".
+                # Fetch the real file and re-test.  This serves two purposes:
+                # 1. When the snippet doesn't detect: distinguish "snippet too
+                #    narrow" from "genuine code bug".
+                # 2. When the snippet DOES detect an FN: confirm whether the
+                #    full file also detects.  If not, the full-file context
+                #    (e.g., rubocop:disable comments, begin/rescue wrappers)
+                #    suppresses detection — this is a real bug in how nitrocop
+                #    handles that context, not just a config issue.
                 full_file_detected: bool | None = None
                 full_file_enclosing: str | None = None
                 full_file_context: str | None = None
                 diagnosis_note: str | None = None
 
-                if not detected and (kind == "fn" or kind == "fp"):
-                    parsed = _parse_example_loc(loc)
-                    if parsed:
-                        repo_id, filepath, real_line = parsed
-                        manifest = _load_manifest()
-                        entry = manifest.get(repo_id)
-                        if entry and entry["repo_url"] and entry["sha"]:
-                            content = _fetch_full_file(
-                                entry["repo_url"], entry["sha"], filepath,
+                parsed = _parse_example_loc(loc)
+                if parsed:
+                    repo_id, filepath, real_line = parsed
+                    manifest = _load_manifest()
+                    entry = manifest.get(repo_id)
+                    if entry and entry["repo_url"] and entry["sha"]:
+                        content = _fetch_full_file(
+                            entry["repo_url"], entry["sha"], filepath,
+                        )
+                        if content is not None:
+                            ff_offenses = _run_nitrocop_on_file(
+                                binary_path, content, cop,
+                                filename=filepath,
                             )
-                            if content is not None:
-                                ff_offenses = _run_nitrocop_on_file(
-                                    binary_path, content, cop,
-                                    filename=os.path.basename(filepath),
+                            ff_hit = any(
+                                o.get("line") == real_line
+                                for o in ff_offenses
+                            )
+                            full_file_detected = ff_hit
+
+                            # Build enclosing chain from the full file
+                            full_lines = content.splitlines()
+                            if 0 < real_line <= len(full_lines):
+                                chain = _find_enclosing_structures(
+                                    full_lines, real_line - 1,
+                                    real_line_offset=0,
                                 )
-                                ff_hit = any(
-                                    o.get("line") == real_line
-                                    for o in ff_offenses
+                                if chain:
+                                    full_file_enclosing = " > ".join(chain)
+
+                                # Provide broader context (30 lines before)
+                                ctx_start = max(0, real_line - 1 - 30)
+                                ctx_end = min(len(full_lines), real_line + 7)
+                                ctx_lines = []
+                                for ci in range(ctx_start, ctx_end):
+                                    marker = ">>> " if ci == real_line - 1 else "    "
+                                    ctx_lines.append(
+                                        f"{marker}{ci + 1:>5}: {full_lines[ci]}"
+                                    )
+                                full_file_context = "\n".join(ctx_lines)
+
+                            if not detected and ff_hit and kind == "fn":
+                                diagnosis_note = (
+                                    "Snippet too narrow — offense is detected "
+                                    "in the full file but not in the ±7-line "
+                                    "extract. The enclosing structure chain "
+                                    "shows the missing context."
                                 )
-                                full_file_detected = ff_hit
-
-                                # Build enclosing chain from the full file
-                                full_lines = content.splitlines()
-                                if 0 < real_line <= len(full_lines):
-                                    chain = _find_enclosing_structures(
-                                        full_lines, real_line - 1,
-                                        real_line_offset=0,
-                                    )
-                                    if chain:
-                                        full_file_enclosing = " > ".join(chain)
-
-                                    # Provide broader context (30 lines before)
-                                    ctx_start = max(0, real_line - 1 - 30)
-                                    ctx_end = min(len(full_lines), real_line + 7)
-                                    ctx_lines = []
-                                    for ci in range(ctx_start, ctx_end):
-                                        marker = ">>> " if ci == real_line - 1 else "    "
-                                        ctx_lines.append(
-                                            f"{marker}{ci + 1:>5}: {full_lines[ci]}"
-                                        )
-                                    full_file_context = "\n".join(ctx_lines)
-
-                                if ff_hit and kind == "fn":
-                                    diagnosis_note = (
-                                        "Snippet too narrow — offense is detected "
-                                        "in the full file but not in the ±7-line "
-                                        "extract. The enclosing structure chain "
-                                        "shows the missing context."
-                                    )
-                                elif ff_hit and kind == "fp":
-                                    diagnosis_note = (
-                                        "Snippet too narrow — FP reproduces in "
-                                        "the full file but not in the ±7-line "
-                                        "extract. This is a real code/config bug, "
-                                        "not just context-dependent."
-                                    )
+                            elif not detected and ff_hit and kind == "fp":
+                                diagnosis_note = (
+                                    "Snippet too narrow — FP reproduces in "
+                                    "the full file but not in the ±7-line "
+                                    "extract. This is a real code/config bug, "
+                                    "not just context-dependent."
+                                )
+                            elif detected and not ff_hit and kind == "fn":
+                                diagnosis_note = (
+                                    "Snippet detects but full file does not — "
+                                    "something in the full-file context "
+                                    "(rubocop:disable comment, begin/rescue "
+                                    "wrapper, config interaction) suppresses "
+                                    "detection. This is a real code bug, not "
+                                    "a project config issue."
+                                )
 
                 results.append({
                     "kind": kind, "loc": loc, "msg": msg,
@@ -989,16 +1002,26 @@ def _format_with_diagnostics(
     fn_undiagnosed = [d for d in fn_diags if not d.get("diagnosed")]
     fp_undiagnosed = [d for d in fp_diags if not d.get("diagnosed")]
 
-    # Summary counts — full-file fallback can reclassify snippet misses
+    # Summary counts — full-file fallback can reclassify snippet misses.
+    # A FN is a "code bug" when:
+    #   - Neither snippet nor full-file detects it (classic code bug), OR
+    #   - Snippet detects but full-file does NOT (context-sensitive bug:
+    #     something in the real file suppresses detection, e.g. a
+    #     rubocop:disable comment nitrocop mishandles, a begin/rescue
+    #     wrapper, or a config interaction bug).
     fn_code_bugs = sum(
         1 for d in fn_diagnosed
-        if not d.get("detected") and not d.get("full_file_detected")
+        if (not d.get("detected") and not d.get("full_file_detected"))
+        or (d.get("detected") and d.get("full_file_detected") is False)
     )
     fn_context_narrow = sum(
         1 for d in fn_diagnosed
         if not d.get("detected") and d.get("full_file_detected")
     )
-    fn_config = sum(1 for d in fn_diagnosed if d.get("detected"))
+    fn_config = sum(
+        1 for d in fn_diagnosed
+        if d.get("detected") and d.get("full_file_detected") is not False
+    )
     fp_code_bugs = sum(
         1 for d in fp_diagnosed
         if d.get("detected") or d.get("full_file_detected")
@@ -1014,7 +1037,8 @@ def _format_with_diagnostics(
 
     lines.append("### Diagnosis Summary")
     lines.append("Each example was tested by running nitrocop on the extracted source in isolation")
-    lines.append("with `--force-default-config` to determine if the issue is a code bug or config issue.")
+    lines.append("and against the full file fetched from GitHub to determine if the issue is a")
+    lines.append("code bug or config issue.")
     lines.append("Note: source context is truncated and may not parse perfectly. If a diagnosis")
     lines.append("seems wrong (e.g., your test passes immediately for a 'CODE BUG'), treat it as")
     lines.append("a config/context issue instead.\n")
@@ -1065,7 +1089,17 @@ def _format_with_diagnostics(
     for i, d in enumerate(fn_display, 1):
         lines.append(f"### FN #{i}: `{d['loc']}`")
         if d.get("diagnosed"):
-            if d.get("detected"):
+            if d.get("detected") and d.get("full_file_detected") is False:
+                lines.append("**DETECTED in snippet but NOT in full file — CODE BUG**")
+                lines.append("The cop detects the pattern in a small snippet but fails")
+                lines.append("when the full file is present. Something in the file context")
+                lines.append("(rubocop:disable comment, begin/rescue wrapper, or config")
+                lines.append("interaction) incorrectly suppresses detection.")
+                if d.get("diagnosis_note"):
+                    lines.append(f"\n> {d['diagnosis_note']}")
+                if d.get("full_file_enclosing"):
+                    lines.append(f"\n**Full-file enclosing chain:** {d['full_file_enclosing']}")
+            elif d.get("detected"):
                 lines.append("**DETECTED in isolation — CONFIG/CONTEXT issue**")
                 lines.append("The cop correctly detects this pattern with default config.")
                 lines.append("The corpus FN is caused by the target repo's configuration")
@@ -1291,6 +1325,10 @@ def generate_task(
             if not d.get("diagnosed"):
                 continue
             if d["kind"] == "fn" and not d.get("detected") and not d.get("full_file_detected"):
+                has_code_bugs = True
+            elif d["kind"] == "fn" and d.get("detected") and d.get("full_file_detected") is False:
+                # Snippet detects but full file doesn't → context-sensitive
+                # code bug (e.g. rubocop:disable handling, begin/rescue).
                 has_code_bugs = True
             elif d["kind"] == "fn" and (d.get("detected") or d.get("full_file_detected")):
                 has_config_issues = True

--- a/scripts/verify_cop_locations.py
+++ b/scripts/verify_cop_locations.py
@@ -106,21 +106,30 @@ def parse_loc(loc_str: str) -> tuple[str, str, int]:
 def run_nitrocop_on_repo(
     nitrocop_bin: Path, corpus_dir: Path, config_path: Path,
     repo_id: str, filepaths: list[str], cop_name: str,
-) -> dict[str, set[int]]:
-    """Run nitrocop once on all files in a repo, return {filepath: set of offense lines}."""
+) -> dict[str, set[int]] | None:
+    """Run nitrocop once on all files in a repo, return {filepath: set of offense lines}.
+
+    Returns None when the repo directory doesn't exist or none of the
+    requested files are on disk.  Callers must distinguish None (not
+    checked) from an empty-set result (checked, no offenses found).
+    """
     # Import shared corpus runner for oracle-identical env/config
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "bench" / "corpus"))
     from run_nitrocop import build_env, resolve_repo_config
 
     repo_dir = corpus_dir / repo_id
+    if not repo_dir.is_dir():
+        return None
+
     existing = []
     for fp in filepaths:
         if (repo_dir / fp).exists():
             existing.append(fp)
 
-    result_map: dict[str, set[int]] = {fp: set() for fp in filepaths}
     if not existing:
-        return result_map
+        return None
+
+    result_map: dict[str, set[int]] = {fp: set() for fp in filepaths}
 
     env = build_env(str(repo_dir))
     resolved_config = resolve_repo_config(repo_id, str(repo_dir))
@@ -220,8 +229,10 @@ def main():
 
     overall_fp_fixed = 0
     overall_fp_remain = 0
+    overall_fp_skipped = 0
     overall_fn_fixed = 0
     overall_fn_remain = 0
+    overall_fn_skipped = 0
 
     for cop_name in args.cops:
         cop_data = by_cop.get(cop_name)
@@ -254,7 +265,9 @@ def main():
                 pass
 
         # Batch run nitrocop per repo
-        nitrocop_cache: dict[tuple[str, str], set[int]] = {}
+        # nitrocop_cache values: set[int] = checked, None = repo not cloned
+        nitrocop_cache: dict[tuple[str, str], set[int] | None] = {}
+        skipped_repos: set[str] = set()
         total_repos = len(repo_files)
         for i, (repo_id, files) in enumerate(sorted(repo_files.items()), 1):
             print(f"\r  Scanning repo {i}/{total_repos}: {repo_id[:50]}...  ",
@@ -263,15 +276,27 @@ def main():
                 nitrocop_bin, corpus_dir, config_path,
                 repo_id, sorted(files), cop_name,
             )
-            for fp, lines in result_map.items():
-                nitrocop_cache[(repo_id, fp)] = lines
+            if result_map is None:
+                skipped_repos.add(repo_id)
+                for fp in files:
+                    nitrocop_cache[(repo_id, fp)] = None
+            else:
+                for fp, lines in result_map.items():
+                    nitrocop_cache[(repo_id, fp)] = lines
         if total_repos:
             print(file=sys.stderr)  # clear progress line
+        if skipped_repos:
+            print(
+                f"\n  WARNING: {len(skipped_repos)}/{total_repos} repo(s) not "
+                f"cloned locally — those locations cannot be verified.",
+                file=sys.stderr,
+            )
 
         # Check FPs
         if not args.fn_only and fp_examples:
             fp_fixed = 0
             fp_remain = 0
+            fp_skipped = 0
             print(f"\nFalse Positives ({len(fp_examples)} from CI):")
             for ex in fp_examples:
                 loc = ex["loc"] if isinstance(ex, dict) else ex
@@ -280,10 +305,14 @@ def main():
                     repo_id, filepath, line = parse_loc(loc)
                 except (ValueError, IndexError):
                     print(f"  ? SKIP (can't parse): {loc}")
+                    fp_skipped += 1
                     continue
 
-                nitro_lines = nitrocop_cache.get((repo_id, filepath), set())
-                if line in nitro_lines:
+                cached = nitrocop_cache.get((repo_id, filepath))
+                if cached is None:
+                    print(f"  SKIP    {loc}  (repo not cloned)")
+                    fp_skipped += 1
+                elif line in cached:
                     print(f"  REMAIN  {loc}")
                     if msg:
                         print(f"          {msg}")
@@ -292,14 +321,19 @@ def main():
                     print(f"  FIXED   {loc}")
                     fp_fixed += 1
 
-            print(f"\n  FP summary: {fp_fixed} fixed, {fp_remain} remain")
+            parts = [f"{fp_fixed} fixed", f"{fp_remain} remain"]
+            if fp_skipped:
+                parts.append(f"{fp_skipped} skipped")
+            print(f"\n  FP summary: {', '.join(parts)}")
             overall_fp_fixed += fp_fixed
             overall_fp_remain += fp_remain
+            overall_fp_skipped += fp_skipped
 
         # Check FNs
         if not args.fp_only and fn_examples:
             fn_fixed = 0
             fn_remain = 0
+            fn_skipped = 0
             print(f"\nFalse Negatives ({len(fn_examples)} from CI):")
             for ex in fn_examples:
                 loc = ex["loc"] if isinstance(ex, dict) else ex
@@ -308,10 +342,14 @@ def main():
                     repo_id, filepath, line = parse_loc(loc)
                 except (ValueError, IndexError):
                     print(f"  ? SKIP (can't parse): {loc}")
+                    fn_skipped += 1
                     continue
 
-                nitro_lines = nitrocop_cache.get((repo_id, filepath), set())
-                if line in nitro_lines:
+                cached = nitrocop_cache.get((repo_id, filepath))
+                if cached is None:
+                    print(f"  SKIP    {loc}  (repo not cloned)")
+                    fn_skipped += 1
+                elif line in cached:
                     print(f"  FIXED   {loc}")
                     fn_fixed += 1
                 else:
@@ -320,22 +358,56 @@ def main():
                         print(f"          {msg}")
                     fn_remain += 1
 
-            print(f"\n  FN summary: {fn_fixed} fixed, {fn_remain} remain")
+            parts = [f"{fn_fixed} fixed", f"{fn_remain} remain"]
+            if fn_skipped:
+                parts.append(f"{fn_skipped} skipped")
+            print(f"\n  FN summary: {', '.join(parts)}")
             overall_fn_fixed += fn_fixed
             overall_fn_remain += fn_remain
+            overall_fn_skipped += fn_skipped
 
     # Overall summary
-    print(f"\n{'='*70}")
-    print(f"OVERALL: FP {overall_fp_fixed} fixed / {overall_fp_remain} remain, "
-          f"FN {overall_fn_fixed} fixed / {overall_fn_remain} remain")
+    total_skipped = overall_fp_skipped + overall_fn_skipped
+    total_checked = (overall_fp_fixed + overall_fp_remain
+                     + overall_fn_fixed + overall_fn_remain)
     total_remain = overall_fp_remain + overall_fn_remain
-    if total_remain == 0:
-        print("ALL FP/FN VERIFIED FIXED")
-    else:
+
+    print(f"\n{'='*70}")
+    fp_parts = [f"{overall_fp_fixed} fixed", f"{overall_fp_remain} remain"]
+    fn_parts = [f"{overall_fn_fixed} fixed", f"{overall_fn_remain} remain"]
+    if overall_fp_skipped:
+        fp_parts.append(f"{overall_fp_skipped} skipped")
+    if overall_fn_skipped:
+        fn_parts.append(f"{overall_fn_skipped} skipped")
+    print(f"OVERALL: FP {' / '.join(fp_parts)}, FN {' / '.join(fn_parts)}")
+
+    exit_code = 0 if total_remain == 0 and total_checked > 0 else 1
+
+    if total_skipped and total_checked == 0:
+        print(
+            f"WARNING: All {total_skipped} location(s) skipped — no corpus "
+            f"repos are cloned locally. Results are not meaningful."
+        )
+        if os.environ.get("CI"):
+            print(
+                "ERROR: Running in CI with no checkable repos. Use "
+                "check_cop.py --rerun --clone instead, or clone repos with "
+                "scripts/corpus_repo_map.py --clone.",
+                file=sys.stderr,
+            )
+            exit_code = 2
+    elif total_skipped:
+        print(
+            f"NOTE: {total_skipped} location(s) skipped (repos not cloned). "
+            f"Only {total_checked} location(s) were actually verified."
+        )
+    if total_remain == 0 and total_checked > 0:
+        print("ALL CHECKED FP/FN VERIFIED FIXED")
+    elif total_remain > 0:
         print(f"{total_remain} issues remain")
     print(f"{'='*70}")
 
-    sys.exit(0 if total_remain == 0 else 1)
+    sys.exit(exit_code)
 
 
 def _run_tests():

--- a/tests/python/test_dispatch_cops.py
+++ b/tests/python/test_dispatch_cops.py
@@ -131,6 +131,96 @@ def test_detect_prism_pitfalls_none():
     assert len(pitfalls) == 0
 
 
+def test_format_with_diagnostics_fn_snippet_detects_fullfile_does_not_is_code_bug():
+    """When snippet detects an FN but the full-file test does NOT detect it,
+    it should be classified as a CODE BUG (context-sensitive detection failure)."""
+    diagnostics = [
+        {
+            "kind": "fn",
+            "loc": "repo: file.rb:10",
+            "msg": "Missing method",
+            "diagnosed": True,
+            "detected": True,           # snippet detects
+            "full_file_detected": False,  # full file does NOT detect
+            "offense_line": "def foo; end",
+            "test_snippet": "def foo; end\n^ Lint/Syntax: Missing method",
+            "enclosing": None,
+            "node_type": None,
+            "source_context": "def foo; end",
+            "full_file_enclosing": "block (do..end) > class body",
+            "full_file_context": "...",
+            "diagnosis_note": "Snippet detects but full file does not",
+        },
+    ]
+    output = gct._format_with_diagnostics(
+        "Lint/Syntax",
+        diagnostics,
+        fp_examples=[],
+        fn_examples=[{"loc": "repo: file.rb:10", "msg": "Missing method"}],
+    )
+    # Should be counted as a code bug, not a config/context issue
+    assert "1 code bug(s)" in output
+    assert "config/context issue(s)" not in output
+    # The formatted output should contain the CODE BUG marker
+    assert "— CODE BUG" in output
+
+
+def test_format_with_diagnostics_fn_snippet_and_fullfile_both_detect_is_config():
+    """When both snippet AND full-file detect an FN, the corpus mismatch is
+    truly a config/context issue (the project's config suppresses it)."""
+    diagnostics = [
+        {
+            "kind": "fn",
+            "loc": "repo: file.rb:10",
+            "msg": "Missing method",
+            "diagnosed": True,
+            "detected": True,            # snippet detects
+            "full_file_detected": True,   # full file also detects
+            "offense_line": "def foo; end",
+            "test_snippet": "def foo; end\n^ Lint/Syntax: Missing method",
+            "enclosing": None,
+            "node_type": None,
+            "source_context": "def foo; end",
+        },
+    ]
+    output = gct._format_with_diagnostics(
+        "Lint/Syntax",
+        diagnostics,
+        fp_examples=[],
+        fn_examples=[{"loc": "repo: file.rb:10", "msg": "Missing method"}],
+    )
+    # Should be classified as config/context, not a code bug
+    assert "1 config/context issue(s)" in output
+    assert "CONFIG/CONTEXT issue" in output
+
+
+def test_format_with_diagnostics_fn_snippet_detects_fullfile_none_is_config():
+    """When snippet detects but full_file_detected is None (fetch failed),
+    fall back to the original CONFIG/CONTEXT classification."""
+    diagnostics = [
+        {
+            "kind": "fn",
+            "loc": "repo: file.rb:10",
+            "msg": "Missing method",
+            "diagnosed": True,
+            "detected": True,
+            "full_file_detected": None,  # fetch failed, no full-file result
+            "offense_line": "def foo; end",
+            "test_snippet": None,
+            "enclosing": None,
+            "node_type": None,
+            "source_context": "def foo; end",
+        },
+    ]
+    output = gct._format_with_diagnostics(
+        "Lint/Syntax",
+        diagnostics,
+        fp_examples=[],
+        fn_examples=[{"loc": "repo: file.rb:10", "msg": "Missing method"}],
+    )
+    assert "1 config/context issue(s)" in output
+
+
 def test_format_with_diagnostics_omits_no_source_examples_when_diagnosed_exists():
     diagnostics = [
         {

--- a/tests/python/test_verify_cop_locations.py
+++ b/tests/python/test_verify_cop_locations.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Tests for verify_cop_locations.py — SKIP vs FIXED distinction."""
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# verify_cop_locations.py imports from shared.corpus_artifacts which lives
+# under scripts/.  Add scripts/ to sys.path so the import resolves.
+_scripts_dir = str(Path(__file__).parents[2] / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+SCRIPT = Path(__file__).parents[2] / "scripts" / "verify_cop_locations.py"
+SPEC = importlib.util.spec_from_file_location("verify_cop_locations", SCRIPT)
+assert SPEC and SPEC.loader
+vcl = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(vcl)
+
+
+def test_run_nitrocop_on_repo_returns_none_when_repo_dir_missing(tmp_path):
+    """When the corpus repo directory doesn't exist, return None (not empty sets)."""
+    corpus_dir = tmp_path / "corpus"
+    corpus_dir.mkdir()
+    # repo dir does NOT exist
+    result = vcl.run_nitrocop_on_repo(
+        Path("/nonexistent/nitrocop"),
+        corpus_dir,
+        Path("/nonexistent/config.yml"),
+        "some_repo__abc123",
+        ["lib/foo.rb", "lib/bar.rb"],
+        "Style/Foo",
+    )
+    assert result is None
+
+
+def test_run_nitrocop_on_repo_returns_none_when_no_files_exist(tmp_path):
+    """When the repo dir exists but none of the requested files are on disk,
+    return None."""
+    corpus_dir = tmp_path / "corpus"
+    repo_dir = corpus_dir / "some_repo__abc123"
+    repo_dir.mkdir(parents=True)
+    result = vcl.run_nitrocop_on_repo(
+        Path("/nonexistent/nitrocop"),
+        corpus_dir,
+        Path("/nonexistent/config.yml"),
+        "some_repo__abc123",
+        ["lib/foo.rb"],  # file doesn't exist in repo_dir
+        "Style/Foo",
+    )
+    assert result is None
+
+
+def test_parse_loc():
+    assert vcl.parse_loc("repo__id__abc123: path/to/file.rb:42") == (
+        "repo__id__abc123", "path/to/file.rb", 42,
+    )
+    assert vcl.parse_loc("r: a.rb:1") == ("r", "a.rb", 1)
+    # Path with colon
+    assert vcl.parse_loc("repo: dir/sub:file.rb:99") == (
+        "repo", "dir/sub:file.rb", 99,
+    )
+
+
+def test_exit_code_nonzero_when_all_skipped(tmp_path, capsys):
+    """When all locations are skipped (no repos cloned), exit code should be 1
+    (not 0, which would falsely signal 'all fixed')."""
+    # Create minimal corpus-results.json
+    import json
+    results_file = tmp_path / "corpus-results.json"
+    results_file.write_text(json.dumps({
+        "by_cop": [{
+            "cop": "Style/Foo",
+            "fp": 1, "fn": 0, "matches": 10,
+            "fp_examples": [{"loc": "missing_repo__abc: lib/foo.rb:5", "msg": "bad"}],
+            "fn_examples": [],
+        }],
+    }))
+
+    # Patch ensure_fresh_release_binary to no-op, and set corpus_dir to empty
+    with patch.object(vcl, "ensure_fresh_release_binary"):
+        with patch("sys.exit") as mock_exit:
+            # Patch sys.argv for argparse
+            import sys
+            old_argv = sys.argv
+            sys.argv = ["verify_cop_locations.py", "Style/Foo", "--input", str(results_file)]
+            # Patch corpus_dir / nitrocop_bin via find_project_root
+            with patch.object(vcl, "find_project_root", return_value=tmp_path):
+                # Create the vendor/corpus dir but no repos inside
+                (tmp_path / "vendor" / "corpus").mkdir(parents=True)
+                vcl.main()
+            sys.argv = old_argv
+
+    # Should exit with non-zero (1 = issues remain or nothing checked)
+    mock_exit.assert_called()
+    exit_code = mock_exit.call_args[0][0]
+    assert exit_code != 0, "Exit code should be non-zero when all locations skipped"
+
+    captured = capsys.readouterr()
+    assert "SKIP" in captured.out
+    assert "skipped" in captured.out.lower()
+
+
+def test_exit_code_2_in_ci_when_all_skipped(tmp_path, capsys):
+    """In CI (CI env var set), exit with code 2 when all repos are skipped."""
+    import json
+    results_file = tmp_path / "corpus-results.json"
+    results_file.write_text(json.dumps({
+        "by_cop": [{
+            "cop": "Style/Foo",
+            "fp": 1, "fn": 0, "matches": 10,
+            "fp_examples": [{"loc": "missing_repo__abc: lib/foo.rb:5", "msg": "bad"}],
+            "fn_examples": [],
+        }],
+    }))
+
+    with patch.object(vcl, "ensure_fresh_release_binary"):
+        with patch("sys.exit") as mock_exit:
+            import sys
+            old_argv = sys.argv
+            sys.argv = ["verify_cop_locations.py", "Style/Foo", "--input", str(results_file)]
+            with patch.object(vcl, "find_project_root", return_value=tmp_path):
+                (tmp_path / "vendor" / "corpus").mkdir(parents=True)
+                # Set CI env var
+                with patch.dict(os.environ, {"CI": "true"}):
+                    vcl.main()
+            sys.argv = old_argv
+
+    mock_exit.assert_called()
+    exit_code = mock_exit.call_args[0][0]
+    assert exit_code == 2, f"Expected exit code 2 in CI, got {exit_code}"


### PR DESCRIPTION
## Summary

Fixes two root causes of empty bot PRs in the agent-cop-fix workflow:

- **verify_cop_locations.py** now distinguishes "repo not cloned" (SKIP) from "checked, no offenses" (FIXED). Previously, uncloned repos returned empty offense sets that were silently treated as "all fixed" — agents would conclude the cop was already fixed when nothing was actually verified. In CI, exits with code 2 and a clear error when all repos are skipped.

- **dispatch_cops.py** pre-diagnostic now runs the full-file fallback for ALL FN/FP examples, not just snippet-undetected ones. When a snippet detects a pattern but the full file does NOT, this is now classified as a CODE BUG (context-sensitive detection failure) instead of CONFIG/CONTEXT. This prevents false skips like the Lint/Syntax case (run 23934057043) where all examples were incorrectly classified as config issues. Also fixes `_run_nitrocop_on_file` to preserve relative paths for Include pattern matching.

## Context

Investigation of PRs #1305, #1271, #1269, #1266 revealed:
- PRs #1266, #1271: Agents ran `verify_cop_locations.py` on uncloned repos → tool reported all FPs "FIXED" → agents exited with no changes
- Lint/Syntax run 23934057043: All FN examples detected in snippets → classified CONFIG/CONTEXT → `code_bugs=0` → workflow skipped despite real bugs
- Related to the check_cop.py baseline fix (e22dd33e) as part of the same accuracy improvement effort

## Test plan

- [x] `uv run pytest tests/python/ --tb=short` — 393 tests pass (+8 new)
- [x] `uv run ruff check` on all changed files
- [ ] Verify `verify_cop_locations.py` prints SKIP for uncloned repos (no corpus repos in devcontainer)
- [ ] Re-dispatch a cop-fix for a cop with config-only FNs to confirm the new classification dispatches the agent


🤖 Generated with [Claude Code](https://claude.com/claude-code)