### PR TITLE
Add count-level sanity check to cop-check CI comment

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -281,7 +281,7 @@ jobs:
           if [ -d summaries ]; then
             for f in summaries/*.txt; do
               [ -f "$f" ] || continue
-              while IFS='|' read -r cop bl_fp bl_fn local_fp local_fn shard_result; do
+              while IFS='|' read -r cop bl_fp bl_fn local_fp local_fn shard_result count_bl_fp count_bl_fn; do
                 STATUS="✅"
                 [ "$shard_result" = "fail" ] && STATUS="❌"
                 fp_delta=$((local_fp - bl_fp))
@@ -289,7 +289,17 @@ jobs:
                 # Show sign explicitly: +N for regressions, -N for improvements, 0 for unchanged
                 [ "$fp_delta" -gt 0 ] && fp_delta="+${fp_delta}"
                 [ "$fn_delta" -gt 0 ] && fn_delta="+${fn_delta}"
-                BODY+="| \`${cop}\` | ${bl_fp} | ${bl_fn} | ${local_fp} | ${local_fn} | ${fp_delta} | ${fn_delta} | ${STATUS} |\n"
+                # Sanity check: if location-level FP regressed but count-level
+                # shows no excess, the regression is a location shift or config
+                # artifact, not extra offenses. Annotate the status to help triage.
+                NOTE=""
+                if [ -n "$count_bl_fp" ] && [ "$shard_result" = "fail" ]; then
+                  count_fp_delta=$((local_fp - count_bl_fp))
+                  if [ "$count_fp_delta" -le 0 ] && [ "$((local_fp - bl_fp))" -gt 0 ]; then
+                    NOTE=" ⚠️ count Δ=${count_fp_delta}"
+                  fi
+                fi
+                BODY+="| \`${cop}\` | ${bl_fp} | ${bl_fn} | ${local_fp} | ${local_fn} | ${fp_delta} | ${fn_delta} | ${STATUS}${NOTE} |\n"
               done < "$f"
             done
           else

--- a/scripts/check_cop.py
+++ b/scripts/check_cop.py
@@ -1036,6 +1036,8 @@ def main():
         total_baseline_fn = 0
         total_local_fp = 0
         total_local_fn = 0
+        total_count_baseline_fp = 0
+        total_count_baseline_fn = 0
         fp_repos = []
         fn_repos = []
         # Build per-repo baseline counts from the oracle.
@@ -1086,6 +1088,12 @@ def main():
             baseline_fn = oracle_location_fn.get(repo_id, 0)
             total_baseline_fp += baseline_fp
             total_baseline_fn += baseline_fn
+            # Also track count-level baseline for sanity-check annotation.
+            # Count-level FP = max(0, nitrocop_count - rubocop_count).
+            count_bl_fp = max(0, baseline_nc - baseline_rc)
+            count_bl_fn = max(0, baseline_rc - baseline_nc)
+            total_count_baseline_fp += count_bl_fp
+            total_count_baseline_fn += count_bl_fn
             # How far is the local nitrocop from rubocop?
             local_fp = max(0, local_count - baseline_rc)
             local_fn = max(0, baseline_rc - local_count)
@@ -1172,10 +1180,15 @@ def main():
             print()
 
         # Machine-readable summary for CI aggregation
-        # Format: cop|baseline_fp|baseline_fn|local_fp|local_fn|result
-        # local_fp/fn are the actual FP/FN counts from this run (not just regressions)
+        # Format: cop|baseline_fp|baseline_fn|local_fp|local_fn|result|count_bl_fp|count_bl_fn
+        # baseline_fp/fn = location-level from oracle
+        # local_fp/fn = count-level from local run (max(0, local - rubocop))
+        # count_bl_fp/fn = count-level baseline (max(0, oracle_nc - oracle_rc))
+        # The last two fields enable the CI comment to detect when a large
+        # location-level FP delta has no count-level counterpart (location
+        # shift or config resolution artifact, not a real regression).
         result_str = "fail" if failed else "pass"
-        print(f"SUMMARY|{args.cop}|{total_baseline_fp}|{total_baseline_fn}|{total_local_fp}|{total_local_fn}|{result_str}")
+        print(f"SUMMARY|{args.cop}|{total_baseline_fp}|{total_baseline_fn}|{total_local_fp}|{total_local_fn}|{result_str}|{total_count_baseline_fp}|{total_count_baseline_fn}")
 
         if failed:
             sys.exit(1)

--- a/tests/python/test_check_cop.py
+++ b/tests/python/test_check_cop.py
@@ -179,6 +179,7 @@ def _compute_gate(by_repo_cop, cop, per_repo):
     resolved_fp, resolved_fn = 0, 0
     total_baseline_fp, total_baseline_fn = 0, 0
     total_local_fp, total_local_fn = 0, 0
+    total_count_baseline_fp, total_count_baseline_fn = 0, 0
     for repo_id, local_count in per_repo.items():
         bl_nc = oracle_nitrocop_counts.get(repo_id)
         bl_rc = oracle_rubocop_counts.get(repo_id)
@@ -188,6 +189,10 @@ def _compute_gate(by_repo_cop, cop, per_repo):
         baseline_fn = oracle_location_fn.get(repo_id, 0)
         total_baseline_fp += baseline_fp
         total_baseline_fn += baseline_fn
+        count_bl_fp = max(0, bl_nc - bl_rc)
+        count_bl_fn = max(0, bl_rc - bl_nc)
+        total_count_baseline_fp += count_bl_fp
+        total_count_baseline_fn += count_bl_fn
         local_fp = max(0, local_count - bl_rc)
         local_fn = max(0, bl_rc - local_count)
         total_local_fp += local_fp
@@ -208,6 +213,8 @@ def _compute_gate(by_repo_cop, cop, per_repo):
         "net_fp": net_fp, "net_fn": net_fn,
         "total_baseline_fp": total_baseline_fp, "total_baseline_fn": total_baseline_fn,
         "total_local_fp": total_local_fp, "total_local_fn": total_local_fn,
+        "total_count_baseline_fp": total_count_baseline_fp,
+        "total_count_baseline_fn": total_count_baseline_fn,
     }
 
 
@@ -422,6 +429,36 @@ def test_summary_shows_improvement_correctly():
     assert g["total_local_fp"] == 2
     assert g["resolved_fp"] == 3
     assert g["new_fp"] == 0
+
+
+def test_count_level_baseline_detects_location_shift():
+    """When location-level FP increases but count-level doesn't, it's a location shift."""
+    by_repo_cop = {
+        # Oracle: nitrocop=100 (95 match + 5 FP), rubocop=98 (95 match + 3 FN)
+        # Location-level: FP=5, FN=3. Count-level: FP=max(0,100-98)=2.
+        "repo-a": {"Style/Foo": {"matches": 95, "fp": 5, "fn": 3}},
+    }
+    # Local produces 100 (same count as oracle nitrocop) but at different locations.
+    # Location-level FP could be higher, but count-level FP = max(0,100-98) = 2.
+    g = _compute_gate(by_repo_cop, "Style/Foo", {"repo-a": 100})
+    assert g["total_baseline_fp"] == 5       # location-level from oracle
+    assert g["total_count_baseline_fp"] == 2  # count-level from oracle
+    assert g["total_local_fp"] == 2           # count-level from local
+    # No count-level regression: local count FP (2) <= count baseline FP (2)
+    # Even though location-level baseline was 5, count tells us no extra offenses.
+
+
+def test_count_level_baseline_detects_real_regression():
+    """When both location and count-level FP increase, it's a real regression."""
+    by_repo_cop = {
+        # Oracle: nitrocop=10 (10 match + 0 FP), rubocop=10 (10 match + 0 FN)
+        "repo-a": {"Style/Foo": {"matches": 10, "fp": 0, "fn": 0}},
+    }
+    # Local produces 15 → 5 more than rubocop → real FP
+    g = _compute_gate(by_repo_cop, "Style/Foo", {"repo-a": 15})
+    assert g["total_count_baseline_fp"] == 0
+    assert g["total_local_fp"] == 5
+    assert g["new_fp"] == 5  # real regression
 
 
 # ── sampling tests for relevant_repos_for_cop ──


### PR DESCRIPTION
## Summary

- When cop-check shows a large location-level FP regression, annotate the row with the count-level delta so reviewers can immediately tell if it's a real regression vs a location shift / config artifact
- This would have saved significant investigation time on PR #1304 where shard 11 showed +331 location-level FP but count-level showed 0 excess

## Details

The cop-check SUMMARY line now includes count-level baseline FP/FN (computed as `max(0, oracle_nc - oracle_rc)`). The CI comment bash parses these and annotates failing rows:

- `❌ ⚠️ count Δ=0` — location-level FP regressed but no count-level excess (location shift or config artifact)
- `❌` (no annotation) — both location and count regressed (real regression)

## Test plan

- [x] `uv run pytest tests/python/` — 395 pass (2 new tests)
- [x] `uv run ruff check` — clean
- [ ] Verify annotation renders correctly on a PR with mixed pass/fail shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)