### PR TITLE
Fix TOCTOU race in 3 VariableForce cops: Mutex → thread_local!

### DIFF
--- a/src/cop/lint/unused_method_argument.rs
+++ b/src/cop/lint/unused_method_argument.rs
@@ -1,5 +1,5 @@
+use std::cell::RefCell;
 use std::collections::HashSet;
-use std::sync::Mutex;
 
 use crate::cop::variable_force::{self, Scope, VariableTable};
 use crate::cop::{Cop, CopConfig};
@@ -9,6 +9,14 @@ use ruby_prism::Visit;
 
 use super::super::variable_force::scope::ScopeKind;
 use super::super::variable_force::variable::DeclarationKind;
+
+// Thread-local storage for per-file context data. Within a rayon task, a single
+// file is processed sequentially: check_source -> VF engine ->
+// before_leaving_scope, so thread-local storage is safe and avoids the
+// TOCTOU race that Mutex fields on the shared cop struct would cause.
+thread_local! {
+    static UNUSED_METHOD_ARG_SKIPS: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
+}
 
 /// Checks for unused method arguments.
 ///
@@ -58,23 +66,17 @@ use super::super::variable_force::variable::DeclarationKind;
 /// VariableForce engine. A minimal `check_source` pass pre-computes which def
 /// scopes should be skipped (empty methods, not-implemented stubs). The VF
 /// `before_leaving_scope` hook then checks each argument variable for usage.
-pub struct UnusedMethodArgument {
-    /// Byte offsets of def nodes whose bodies are empty or raise NotImplementedError.
-    /// Populated by `check_source`, consumed by `before_leaving_scope`.
-    skip_offsets: Mutex<HashSet<usize>>,
-}
+pub struct UnusedMethodArgument;
 
 impl UnusedMethodArgument {
     pub fn new() -> Self {
-        Self {
-            skip_offsets: Mutex::new(HashSet::new()),
-        }
+        Self
     }
 }
 
 impl Default for UnusedMethodArgument {
     fn default() -> Self {
-        Self::new()
+        Self
     }
 }
 
@@ -107,7 +109,9 @@ impl Cop for UnusedMethodArgument {
             not_implemented_exceptions,
         };
         collector.visit(&parse_result.node());
-        *self.skip_offsets.lock().unwrap() = collector.offsets;
+        UNUSED_METHOD_ARG_SKIPS.with(|cell| {
+            *cell.borrow_mut() = collector.offsets;
+        });
     }
 
     fn as_variable_force_consumer(&self) -> Option<&dyn variable_force::VariableForceConsumer> {
@@ -130,12 +134,9 @@ impl variable_force::VariableForceConsumer for UnusedMethodArgument {
         }
 
         // Check if this scope should be skipped (empty or not-implemented)
-        if self
-            .skip_offsets
-            .lock()
-            .unwrap()
-            .contains(&scope.node_start_offset)
-        {
+        let should_skip =
+            UNUSED_METHOD_ARG_SKIPS.with(|cell| cell.borrow().contains(&scope.node_start_offset));
+        if should_skip {
             return;
         }
 

--- a/src/cop/style/infinite_loop.rs
+++ b/src/cop/style/infinite_loop.rs
@@ -1,5 +1,5 @@
+use std::cell::RefCell;
 use std::collections::HashSet;
-use std::sync::Mutex;
 
 use crate::cop::shared::literal_predicates;
 use crate::cop::variable_force::{self, Scope, VariableTable};
@@ -97,28 +97,44 @@ use ruby_prism::Visit;
 /// exemption (whether converting to `loop do` would break variable visibility).
 /// This replaces the previous 544-line standalone AST visitor with ~200 lines
 /// of VF-integrated code.
-pub struct InfiniteLoop {
+pub struct InfiniteLoop;
+
+// Thread-local storage for per-file context data. Within a rayon task, a single
+// file is processed sequentially: check_source -> VF engine ->
+// before_leaving_scope, so thread-local storage is safe and avoids the
+// TOCTOU race that Mutex fields on the shared cop struct would cause.
+thread_local! {
+    static INFINITE_LOOP_CTX: RefCell<InfiniteLoopCtx> = RefCell::new(InfiniteLoopCtx::new());
+}
+
+struct InfiniteLoopCtx {
     /// Potential offenses found by `check_source`. Each entry is a loop that
     /// has a truthy/falsey condition. The VF hook will filter out loops where
     /// the conversion would break variable scoping.
-    loops: Mutex<Vec<LoopInfo>>,
+    loops: Vec<LoopInfo>,
     /// Loop offsets that have already been processed by an inner scope's
     /// `before_leaving_scope`. Prevents duplicate emissions from outer scopes.
-    processed: Mutex<HashSet<usize>>,
+    processed: HashSet<usize>,
+}
+
+impl InfiniteLoopCtx {
+    fn new() -> Self {
+        Self {
+            loops: Vec::new(),
+            processed: HashSet::new(),
+        }
+    }
 }
 
 impl InfiniteLoop {
     pub fn new() -> Self {
-        Self {
-            loops: Mutex::new(Vec::new()),
-            processed: Mutex::new(HashSet::new()),
-        }
+        Self
     }
 }
 
 impl Default for InfiniteLoop {
     fn default() -> Self {
-        Self::new()
+        Self
     }
 }
 
@@ -152,8 +168,11 @@ impl Cop for InfiniteLoop {
     ) {
         let mut collector = LoopCollector { loops: Vec::new() };
         collector.visit(&parse_result.node());
-        *self.loops.lock().unwrap() = collector.loops;
-        self.processed.lock().unwrap().clear();
+        INFINITE_LOOP_CTX.with(|cell| {
+            let mut ctx = cell.borrow_mut();
+            ctx.loops = collector.loops;
+            ctx.processed.clear();
+        });
     }
 
     fn as_variable_force_consumer(&self) -> Option<&dyn variable_force::VariableForceConsumer> {
@@ -170,37 +189,39 @@ impl variable_force::VariableForceConsumer for InfiniteLoop {
         _config: &CopConfig,
         diagnostics: &mut Vec<Diagnostic>,
     ) {
-        let loops = self.loops.lock().unwrap();
-        let mut processed = self.processed.lock().unwrap();
+        INFINITE_LOOP_CTX.with(|cell| {
+            let mut guard = cell.borrow_mut();
+            let ctx = &mut *guard;
 
-        for loop_info in loops.iter() {
-            // Skip loops already handled by an inner scope.
-            if processed.contains(&loop_info.loop_start) {
-                continue;
+            for loop_info in ctx.loops.iter() {
+                // Skip loops already handled by an inner scope.
+                if ctx.processed.contains(&loop_info.loop_start) {
+                    continue;
+                }
+
+                // The loop must be inside this scope's range.
+                if loop_info.loop_start < scope.node_start_offset
+                    || loop_info.loop_end > scope.node_end_offset
+                {
+                    continue;
+                }
+
+                // Mark as processed so outer scopes don't re-emit.
+                ctx.processed.insert(loop_info.loop_start);
+
+                if would_break_scoping(scope, variable_table, loop_info) {
+                    continue;
+                }
+
+                let (line, column) = source.offset_to_line_col(loop_info.keyword_offset);
+                diagnostics.push(self.diagnostic(
+                    source,
+                    line,
+                    column,
+                    "Use `Kernel#loop` for infinite loops.".to_string(),
+                ));
             }
-
-            // The loop must be inside this scope's range.
-            if loop_info.loop_start < scope.node_start_offset
-                || loop_info.loop_end > scope.node_end_offset
-            {
-                continue;
-            }
-
-            // Mark as processed so outer scopes don't re-emit.
-            processed.insert(loop_info.loop_start);
-
-            if would_break_scoping(scope, variable_table, loop_info) {
-                continue;
-            }
-
-            let (line, column) = source.offset_to_line_col(loop_info.keyword_offset);
-            diagnostics.push(self.diagnostic(
-                source,
-                line,
-                column,
-                "Use `Kernel#loop` for infinite loops.".to_string(),
-            ));
-        }
+        });
     }
 }
 

--- a/src/cop/style/map_into_array.rs
+++ b/src/cop/style/map_into_array.rs
@@ -1,4 +1,4 @@
-use std::sync::Mutex;
+use std::cell::RefCell;
 
 use crate::cop::variable_force::{self, Scope, VariableTable};
 use crate::cop::{Cop, CopConfig};
@@ -55,23 +55,25 @@ use ruby_prism::Visit;
 /// candidates using VF's complete variable lifetime data. This removed
 /// ~120 lines of manual `contains_binding_call`, `references_variable`,
 /// and `is_local_var_*_write` helpers.
-pub struct MapIntoArray {
-    /// Candidate offenses found by `check_source` pattern matching.
-    /// Validated by `before_leaving_scope` using VF variable data.
-    candidates: Mutex<Vec<Candidate>>,
+pub struct MapIntoArray;
+
+// Thread-local storage for per-file candidate data. Within a rayon task, a single
+// file is processed sequentially: check_source -> VF engine ->
+// before_leaving_scope, so thread-local storage is safe and avoids the
+// TOCTOU race that Mutex fields on the shared cop struct would cause.
+thread_local! {
+    static MAP_INTO_ARRAY_CTX: RefCell<Vec<Candidate>> = const { RefCell::new(Vec::new()) };
 }
 
 impl MapIntoArray {
     pub fn new() -> Self {
-        Self {
-            candidates: Mutex::new(Vec::new()),
-        }
+        Self
     }
 }
 
 impl Default for MapIntoArray {
     fn default() -> Self {
-        Self::new()
+        Self
     }
 }
 
@@ -189,7 +191,9 @@ impl Cop for MapIntoArray {
             candidates: Vec::new(),
         };
         finder.visit(&parse_result.node());
-        *self.candidates.lock().unwrap() = finder.candidates;
+        MAP_INTO_ARRAY_CTX.with(|cell| {
+            *cell.borrow_mut() = finder.candidates;
+        });
     }
 
     fn as_variable_force_consumer(&self) -> Option<&dyn variable_force::VariableForceConsumer> {
@@ -206,99 +210,107 @@ impl variable_force::VariableForceConsumer for MapIntoArray {
         _config: &CopConfig,
         diagnostics: &mut Vec<Diagnostic>,
     ) {
-        let candidates = self.candidates.lock().unwrap();
-        for candidate in candidates.iter() {
-            // Check if the candidate's variable exists in this scope
-            let var = match scope.variables.get(&candidate.var_name) {
-                Some(v) => v,
-                None => continue,
-            };
+        MAP_INTO_ARRAY_CTX.with(|cell| {
+            let candidates = cell.borrow();
+            for candidate in candidates.iter() {
+                // Check if the candidate's variable exists in this scope
+                let var = match scope.variables.get(&candidate.var_name) {
+                    Some(v) => v,
+                    None => continue,
+                };
 
-            match &candidate.kind {
-                CandidateKind::EachPush {
-                    block_body_start,
-                    block_body_end,
-                } => {
-                    // Check that the variable's init assignment is within this scope
-                    // and matches the expected offset
-                    let has_init = var
-                        .assignments
-                        .iter()
-                        .any(|a| a.node_offset == candidate.init_offset && !a.is_operator());
-                    if !has_init {
-                        continue;
+                match &candidate.kind {
+                    CandidateKind::EachPush {
+                        block_body_start,
+                        block_body_end,
+                    } => {
+                        // Check that the variable's init assignment is within this scope
+                        // and matches the expected offset
+                        let has_init = var
+                            .assignments
+                            .iter()
+                            .any(|a| a.node_offset == candidate.init_offset && !a.is_operator());
+                        if !has_init {
+                            continue;
+                        }
+
+                        // Check no explicit references between init and each offsets
+                        let has_intermediate_ref = var.references.iter().any(|r| {
+                            r.explicit
+                                && r.node_offset > candidate.init_offset
+                                && r.node_offset < candidate.each_offset
+                        });
+                        if has_intermediate_ref {
+                            continue;
+                        }
+
+                        // Check no operator/or/and assignments between init and each
+                        let has_intermediate_operator_assign = var.assignments.iter().any(|a| {
+                            a.is_operator()
+                                && a.node_offset > candidate.init_offset
+                                && a.node_offset < candidate.each_offset
+                        });
+                        if has_intermediate_operator_assign {
+                            continue;
+                        }
+
+                        // Check no implicit references (from binding) within the block body.
+                        // VF's engine adds implicit references when it encounters `binding`
+                        // calls, with the offset of the `binding` call site.
+                        let has_binding_in_block = var.references.iter().any(|r| {
+                            !r.explicit
+                                && r.node_offset >= *block_body_start
+                                && r.node_offset <= *block_body_end
+                        });
+                        if has_binding_in_block {
+                            continue;
+                        }
+
+                        diagnostics.push(
+                            self.diagnostic(
+                                source,
+                                candidate.line,
+                                candidate.column,
+                                "Use `map` instead of `each` to map elements into an array."
+                                    .to_string(),
+                            ),
+                        );
                     }
+                    CandidateKind::TapEachPush {
+                        param_offset,
+                        block_body_start,
+                        block_body_end,
+                    } => {
+                        // Verify this is the right scope: the variable's declaration
+                        // must match the tap block parameter offset.
+                        if var.declaration_offset != *param_offset {
+                            continue;
+                        }
 
-                    // Check no explicit references between init and each offsets
-                    let has_intermediate_ref = var.references.iter().any(|r| {
-                        r.explicit
-                            && r.node_offset > candidate.init_offset
-                            && r.node_offset < candidate.each_offset
-                    });
-                    if has_intermediate_ref {
-                        continue;
+                        // For tap pattern, dest var is a block parameter.
+                        // Only need to check for binding in the each block body.
+                        let has_binding_in_block = var.references.iter().any(|r| {
+                            !r.explicit
+                                && r.node_offset >= *block_body_start
+                                && r.node_offset <= *block_body_end
+                        });
+                        if has_binding_in_block {
+                            continue;
+                        }
+
+                        diagnostics.push(
+                            self.diagnostic(
+                                source,
+                                candidate.line,
+                                candidate.column,
+                                "Use `map` instead of `each` to map elements into an array."
+                                    .to_string(),
+                            ),
+                        );
                     }
-
-                    // Check no operator/or/and assignments between init and each
-                    let has_intermediate_operator_assign = var.assignments.iter().any(|a| {
-                        a.is_operator()
-                            && a.node_offset > candidate.init_offset
-                            && a.node_offset < candidate.each_offset
-                    });
-                    if has_intermediate_operator_assign {
-                        continue;
-                    }
-
-                    // Check no implicit references (from binding) within the block body.
-                    // VF's engine adds implicit references when it encounters `binding`
-                    // calls, with the offset of the `binding` call site.
-                    let has_binding_in_block = var.references.iter().any(|r| {
-                        !r.explicit
-                            && r.node_offset >= *block_body_start
-                            && r.node_offset <= *block_body_end
-                    });
-                    if has_binding_in_block {
-                        continue;
-                    }
-
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        candidate.line,
-                        candidate.column,
-                        "Use `map` instead of `each` to map elements into an array.".to_string(),
-                    ));
-                }
-                CandidateKind::TapEachPush {
-                    param_offset,
-                    block_body_start,
-                    block_body_end,
-                } => {
-                    // Verify this is the right scope: the variable's declaration
-                    // must match the tap block parameter offset.
-                    if var.declaration_offset != *param_offset {
-                        continue;
-                    }
-
-                    // For tap pattern, dest var is a block parameter.
-                    // Only need to check for binding in the each block body.
-                    let has_binding_in_block = var.references.iter().any(|r| {
-                        !r.explicit
-                            && r.node_offset >= *block_body_start
-                            && r.node_offset <= *block_body_end
-                    });
-                    if has_binding_in_block {
-                        continue;
-                    }
-
-                    diagnostics.push(self.diagnostic(
-                        source,
-                        candidate.line,
-                        candidate.column,
-                        "Use `map` instead of `each` to map elements into an array.".to_string(),
-                    ));
                 }
             }
-        }
+        });
     }
 }
 


### PR DESCRIPTION
## Summary

- Three VF-consumer cops (`Style/InfiniteLoop`, `Lint/UnusedMethodArgument`, `Style/MapIntoArray`) stored per-file state in `Mutex` fields on the shared cop struct, creating a TOCTOU race under rayon parallelism
- Thread B's `check_source` could overwrite Thread A's Mutex data before Thread A's VF `before_leaving_scope` callback read it, producing non-deterministic FP/FN in parallel corpus runs
- The pre-diagnostic always tested one file at a time (no race), so it classified all FP/FN as CONFIG/CONTEXT → `code_bugs=0` → "cop appears already fixed" → agent never ran — this is why `Style/InfiniteLoop` kept getting dispatched but never fixed
- Migrated all 3 cops to `thread_local!` + `RefCell`, matching the existing pattern used by `ShadowingOuterLocalVariable`, `LeakyLocalVariable`, `SaveBang`, and `OperatorMethodCall`

## Test plan

- [x] `cargo test --release` — all 132 tests pass
- [x] `cargo clippy --release -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [ ] `python3 scripts/check_cop.py Style/InfiniteLoop --rerun` — FP/FN counts should drop after the race is eliminated
- [ ] `python3 scripts/check_cop.py Lint/UnusedMethodArgument --rerun`
- [ ] `python3 scripts/check_cop.py Style/MapIntoArray --rerun`

🤖 Generated with [Claude Code](https://claude.com/claude-code)