### PR TITLE
Extract shared first_non_whitespace helpers to util.rs

### DIFF
--- a/src/cop/layout/space_around_block_parameters.rs
+++ b/src/cop/layout/space_around_block_parameters.rs
@@ -1,4 +1,5 @@
 use crate::cop::shared::node_type::{BLOCK_NODE, LAMBDA_NODE};
+use crate::cop::shared::util;
 use crate::cop::{Cop, CopConfig};
 use crate::diagnostic::Diagnostic;
 use crate::parse::source::SourceFile;
@@ -123,7 +124,9 @@ impl Cop for SpaceAroundBlockParameters {
         if inner_start > inner_end || inner_end > bytes.len() {
             return;
         }
-        let Some(first_non_ws) = first_non_whitespace(bytes, inner_start, inner_end) else {
+        let Some(first_non_ws) =
+            util::first_non_whitespace_offset(bytes, inner_start).filter(|&o| o < inner_end)
+        else {
             return;
         };
         let Some(last_non_ws) = last_non_whitespace(bytes, inner_start, inner_end) else {
@@ -562,10 +565,6 @@ fn locals_only_positions(
         Some(first.location().start_offset()),
         Some(last.location().end_offset()),
     )
-}
-
-fn first_non_whitespace(bytes: &[u8], start: usize, end: usize) -> Option<usize> {
-    (start..end).find(|&idx| !matches!(bytes[idx], b' ' | b'\t' | b'\n' | b'\r'))
 }
 
 fn last_non_whitespace(bytes: &[u8], start: usize, end: usize) -> Option<usize> {

--- a/src/cop/layout/space_around_operators.rs
+++ b/src/cop/layout/space_around_operators.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use crate::cop::shared::util;
 use crate::cop::{Cop, CopConfig};
 use crate::diagnostic::Diagnostic;
 use crate::parse::codemap::CodeMap;
@@ -513,7 +514,7 @@ fn check_text_scanner_extra_space(
         if p < bytes.len() && bytes[p] == b'#' {
             multi_after = false;
         } else if allow_trailing_rhs_alignment {
-            if let Some(rhs_start) = first_non_whitespace_offset_after(bytes, op_end) {
+            if let Some(rhs_start) = util::first_non_space_on_line(bytes, op_end) {
                 if is_aligned_rhs_standalone(source, rhs_start) {
                     multi_after = false;
                 }
@@ -802,18 +803,6 @@ fn line_has_operator_ending_at_col(line: &[u8], target_end_col: usize) -> bool {
     false
 }
 
-fn first_non_whitespace_offset_after(bytes: &[u8], mut offset: usize) -> Option<usize> {
-    while offset < bytes.len() && (bytes[offset] == b' ' || bytes[offset] == b'\t') {
-        offset += 1;
-    }
-
-    if offset < bytes.len() && bytes[offset] != b'\n' && bytes[offset] != b'\r' {
-        Some(offset)
-    } else {
-        None
-    }
-}
-
 fn is_aligned_rhs_standalone(source: &SourceFile, start: usize) -> bool {
     let bytes = source.as_bytes();
     let mut ls = start;
@@ -1074,7 +1063,7 @@ impl OperatorChecker<'_> {
                     if is_aligned_rhs_standalone(self.source, anchor) {
                         multi_space_after = false;
                     }
-                } else if let Some(rhs_start) = first_non_whitespace_offset_after(bytes, end) {
+                } else if let Some(rhs_start) = util::first_non_space_on_line(bytes, end) {
                     if is_aligned_rhs_standalone(self.source, rhs_start) {
                         multi_space_after = false;
                     }

--- a/src/cop/lint/heredoc_method_call_position.rs
+++ b/src/cop/lint/heredoc_method_call_position.rs
@@ -1,5 +1,6 @@
 use ruby_prism::Visit;
 
+use crate::cop::shared::util;
 use crate::cop::{Cop, CopConfig};
 use crate::diagnostic::{Diagnostic, Severity};
 use crate::parse::source::SourceFile;
@@ -63,8 +64,11 @@ impl<'pr> Visit<'pr> for HeredocVisitor<'_, '_> {
                         .filter(|loc| loc.start_offset() >= heredoc_end_offset)
                         .map(|loc| loc.start_offset())
                         .unwrap_or_else(|| {
-                            first_non_whitespace_offset(self.source.as_bytes(), heredoc_end_offset)
-                                .unwrap_or(heredoc_end_offset)
+                            util::first_non_whitespace_offset(
+                                self.source.as_bytes(),
+                                heredoc_end_offset,
+                            )
+                            .unwrap_or(heredoc_end_offset)
                         });
                     let (line, column) = self.source.offset_to_line_col(offense_offset);
                     self.diagnostics.push(self.cop.diagnostic(
@@ -97,14 +101,6 @@ fn heredoc_end_offset(node: &ruby_prism::Node<'_>) -> Option<usize> {
         }
     }
     None
-}
-
-fn first_non_whitespace_offset(bytes: &[u8], start: usize) -> Option<usize> {
-    bytes
-        .get(start..)?
-        .iter()
-        .position(|byte| !byte.is_ascii_whitespace())
-        .map(|offset| start + offset)
 }
 
 #[cfg(test)]

--- a/src/cop/shared/util.rs
+++ b/src/cop/shared/util.rs
@@ -543,6 +543,33 @@ pub fn indentation_of(line: &[u8]) -> usize {
     line.iter().take_while(|&&b| b == b' ').count()
 }
 
+/// Find the first non-whitespace byte offset starting from `start`.
+///
+/// All ASCII whitespace (space, tab, newline, \r, etc.) is skipped.
+/// Returns the absolute byte offset, or `None` if only whitespace remains.
+pub fn first_non_whitespace_offset(bytes: &[u8], start: usize) -> Option<usize> {
+    bytes
+        .get(start..)?
+        .iter()
+        .position(|b| !b.is_ascii_whitespace())
+        .map(|pos| start + pos)
+}
+
+/// Find the first non-space/tab byte offset on the current line starting from `offset`.
+///
+/// Unlike [`first_non_whitespace_offset`], this treats newlines as a boundary:
+/// returns `None` if a newline or end-of-bytes is reached before any visible content.
+pub fn first_non_space_on_line(bytes: &[u8], mut offset: usize) -> Option<usize> {
+    while offset < bytes.len() && (bytes[offset] == b' ' || bytes[offset] == b'\t') {
+        offset += 1;
+    }
+    if offset < bytes.len() && bytes[offset] != b'\n' && bytes[offset] != b'\r' {
+        Some(offset)
+    } else {
+        None
+    }
+}
+
 /// Check if there is a trailing comma between last_element_end and closing_start.
 pub fn has_trailing_comma(
     source_bytes: &[u8],


### PR DESCRIPTION
## Summary
- Consolidate 3 near-identical `first_non_whitespace` functions from individual cops into 2 shared helpers in `src/cop/shared/util.rs`
- `first_non_whitespace_offset(bytes, start)` — skips all ASCII whitespace including newlines
- `first_non_space_on_line(bytes, offset)` — skips space/tab only, returns None at newline boundary
- Removes local copies from `heredoc_method_call_position.rs`, `space_around_block_parameters.rs`, and `space_around_operators.rs`

## Test plan
- [x] All 8 affected cop tests pass (offense + no_offense + autocorrect)
- [x] Full test suite passes (4,655 lib + 132 integration)
- [x] `cargo clippy --release -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)