### PR TITLE
Fix file count including globally-excluded files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod testutil;
 
 use std::collections::{HashMap, HashSet};
 use std::io::Read;
+use std::path::PathBuf;
 
 use anyhow::Result;
 
@@ -28,7 +29,7 @@ use config::load_config;
 use cop::registry::CopRegistry;
 use cop::tiers::{SkipSummary, TierMap};
 use formatter::create_formatter;
-use fs::discover_files;
+use fs::{DiscoveredFiles, discover_files};
 use linter::{lint_source, run_linter};
 use parse::source::SourceFile;
 
@@ -433,32 +434,51 @@ pub fn run(args: Args) -> Result<i32> {
 
     let discovered = discover_files(&args.paths, &config)?;
 
-    // --list-target-files (-L): print files that would be linted, then exit
-    if args.list_target_files {
-        let cop_filters = config.build_cop_filters(&registry, &tier_map, args.preview, &args.paths);
-        for file in &discovered.files {
+    // Build cop filters once (reused for --list-target-files, file filtering, and linting).
+    let cop_filters = config.build_cop_filters(&registry, &tier_map, args.preview, &args.paths);
+
+    // Filter globally-excluded files so they are not counted in "N files inspected"
+    // or given progress dots.  Explicit CLI files bypass AllCops.Exclude unless
+    // --force-exclusion is set (matching RuboCop behavior).
+    let effective_files: Vec<PathBuf> = discovered
+        .files
+        .iter()
+        .filter(|file| {
             if cop_filters.is_globally_excluded(file) {
-                let is_explicit = discovered.explicit.contains(file)
+                let is_explicit = discovered.explicit.contains(file.as_path())
                     || file
                         .canonicalize()
                         .ok()
                         .is_some_and(|c| discovered.explicit.contains(&c));
                 if args.force_exclusion || !is_explicit {
-                    continue;
+                    return false;
                 }
             }
+            true
+        })
+        .cloned()
+        .collect();
+
+    // --list-target-files (-L): print files that would be linted, then exit
+    if args.list_target_files {
+        for file in &effective_files {
             println!("{}", file.display());
         }
         return Ok(0);
     }
 
     if args.debug {
-        eprintln!("debug: {} files to lint", discovered.files.len());
+        eprintln!("debug: {} files to lint", effective_files.len());
         eprintln!("debug: {} cops registered", registry.len());
     }
 
+    let effective_discovered = DiscoveredFiles {
+        files: effective_files,
+        explicit: discovered.explicit,
+    };
+
     let result = run_linter(
-        &discovered,
+        &effective_discovered,
         &config,
         &registry,
         &args,
@@ -489,7 +509,7 @@ pub fn run(args: Args) -> Result<i32> {
     let skip_summary = result.skip_summary.clone();
     let mut formatter = create_formatter(&args.format);
     formatter.set_skip_summary(result.skip_summary);
-    formatter.print(&result.diagnostics, &discovered.files);
+    formatter.print(&result.diagnostics, &effective_discovered.files);
 
     let has_lint_failure = result.diagnostics.iter().any(|d| d.severity >= fail_level);
     let strict_failure = args.strict_scope().is_some_and(|scope| {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1660,6 +1660,55 @@ fn global_exclude_skips_file() {
 }
 
 #[test]
+fn global_exclude_not_counted_in_file_count() {
+    let dir = temp_dir("global_exclude_count");
+    let dir_str = dir.display();
+    let config_yaml = format!("AllCops:\n  Exclude:\n    - '{dir_str}/vendor/**'\n");
+    let config_path = write_file(&dir, ".rubocop.yml", config_yaml.as_bytes());
+    // Two files: one excluded, one not
+    let vendor_file = write_file(&dir, "vendor/foo.rb", b"x = 1  \n");
+    let app_file = write_file(&dir, "app.rb", b"x = 1  \n");
+
+    let config = load_config(Some(config_path.as_path()), None, None).unwrap();
+    let registry = CopRegistry::default_registry();
+    let args = Args {
+        only: vec!["Layout/TrailingWhitespace".to_string()],
+        ..default_args()
+    };
+
+    // Simulate what lib.rs now does: filter before passing to run_linter
+    let all_files = vec![vendor_file, app_file];
+    let cop_filters =
+        config.build_cop_filters(&registry, &TierMap::load(), args.preview, &args.paths);
+    let effective: Vec<PathBuf> = all_files
+        .iter()
+        .filter(|f| !cop_filters.is_globally_excluded(f))
+        .cloned()
+        .collect();
+
+    let result = run_linter(
+        &discovered(&effective),
+        &config,
+        &registry,
+        &args,
+        &TierMap::load(),
+        &AutocorrectAllowlist::load(),
+    );
+
+    assert_eq!(
+        result.file_count, 1,
+        "Globally-excluded files should not be counted; expected 1, got {}",
+        result.file_count
+    );
+    assert!(
+        !result.diagnostics.is_empty(),
+        "The non-excluded file should produce offenses"
+    );
+
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
 fn user_include_override_widens_scope() {
     let dir = temp_dir("user_include_override");
     // CreateTableWithTimestamps defaults to Include: db/migrate/**/*.rb


### PR DESCRIPTION
The "N files inspected" count and progress dots included files matched by AllCops.Exclude that were silently skipped during linting. This made the reported file count higher than RuboCop's on projects with Exclude patterns.

Move the global-exclude filter from inside lint_file (where it returned empty diagnostics but still counted) to before run_linter, so excluded files never reach the formatter. The --list-target-files path already had this filtering and now shares the same pre-computed effective list.