### PR TITLE
CI: use mise-action for Rust to match local dev version

### DIFF
--- a/.github/actions/setup-agent-env/action.yml
+++ b/.github/actions/setup-agent-env/action.yml
@@ -2,9 +2,6 @@ name: Setup Agent Environment
 description: Install Rust, Ruby, mold linker, and corpus bundle for agent workflows
 
 inputs:
-  rust_components:
-    description: Rust toolchain components to install (comma-separated)
-    default: rustfmt
   install_vendor_gems:
     description: Install RuboCop gems from vendor submodule tags (cop-fix only)
     default: 'false'
@@ -15,9 +12,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: jdx/mise-action@v4
       with:
-        components: ${{ inputs.rust_components }}
+        install_args: rust
 
     - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/agent-cop-audit.yml
+++ b/.github/workflows/agent-cop-audit.yml
@@ -57,7 +57,6 @@ jobs:
       # --- Shared environment setup (Rust, Ruby, mold, corpus) ---
       - uses: ./.github/actions/setup-agent-env
         with:
-          rust_components: rustfmt
           install_vendor_gems: 'true'
 
       - name: Set up cargo cache

--- a/.github/workflows/agent-cop-fix.yml
+++ b/.github/workflows/agent-cop-fix.yml
@@ -60,7 +60,6 @@ jobs:
       # --- Shared environment setup (Rust, Ruby, mold, corpus) ---
       - uses: ./.github/actions/setup-agent-env
         with:
-          rust_components: rustfmt
           install_vendor_gems: 'true'
 
       # On self-hosted: copy pre-warmed target into job workspace (each job

--- a/.github/workflows/agent-pr-repair.yml
+++ b/.github/workflows/agent-pr-repair.yml
@@ -346,8 +346,6 @@ jobs:
       # --- Shared environment setup (Rust, Ruby, mold, uv, corpus) ---
       - uses: ./.github/actions/setup-agent-env
         if: steps.pr.outputs.should_run == 'true' && steps.policy.outputs.should_repair == 'true' && steps.repair.outputs.route != 'skip'
-        with:
-          rust_components: rustfmt, clippy
 
       - name: Build release binary for local cop-check diagnosis
         if: steps.pr.outputs.should_run == 'true' && steps.policy.outputs.should_repair == 'true' && steps.verify_meta.outputs.needs_local_cop_check == 'true'

--- a/.github/workflows/batch-dispatch.yml
+++ b/.github/workflows/batch-dispatch.yml
@@ -86,7 +86,6 @@ jobs:
 
       - uses: ./.github/actions/setup-agent-env
         with:
-          rust_components: ''
           install_vendor_gems: 'false'
 
       - name: Build nitrocop binary

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,7 +30,9 @@ jobs:
         with:
           submodules: true
           ref: ${{ inputs.ref || '' }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: jdx/mise-action@v4
+        with:
+          install_args: rust
       - uses: Swatinem/rust-cache@v2
       - name: Build release binary
         run: cargo build --release
@@ -49,9 +51,9 @@ jobs:
           submodules: true
           ref: ${{ inputs.ref || '' }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: jdx/mise-action@v4
         with:
-          components: rustfmt, clippy
+          install_args: rust
 
       - uses: Swatinem/rust-cache@v2
 
@@ -106,7 +108,9 @@ jobs:
         with:
           submodules: true
           ref: ${{ inputs.ref || '' }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: jdx/mise-action@v4
+        with:
+          install_args: rust
       - uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo build --profile ci

--- a/.github/workflows/cop-issue-sync.yml
+++ b/.github/workflows/cop-issue-sync.yml
@@ -28,7 +28,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: jdx/mise-action@v4
+        with:
+          install_args: rust
       - uses: Swatinem/rust-cache@v2
 
       - name: Install mold linker

--- a/.github/workflows/corpus-oracle.yml
+++ b/.github/workflows/corpus-oracle.yml
@@ -33,7 +33,9 @@ jobs:
         with:
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: jdx/mise-action@v4
+        with:
+          install_args: rust
       - uses: Swatinem/rust-cache@v2
 
       - name: Build release binary

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -166,12 +166,11 @@ jobs:
           submodules: true
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: jdx/mise-action@v4
+        with:
+          install_args: rust hyperfine
       - uses: Swatinem/rust-cache@v2
       - uses: ruby/setup-ruby@v1
-
-      - name: Install hyperfine
-        run: cargo install hyperfine
 
       - name: Setup benchmark repo
         run: cargo run --release --bin bench_nitrocop -- setup

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-rust = "1.93.1"
+"rust" = { version = "1.93.1", profile = "default" }
 hyperfine = "1.20.0"
 ruby = "4.0"
 uv = "latest"


### PR DESCRIPTION
## Summary
- Replace `dtolnay/rust-toolchain@stable` with `jdx/mise-action@v4` so CI uses the same Rust version pinned in `mise.toml` (1.93.1) as local dev
- Previously CI used whatever the latest Rust stable was, which drifted from the local pinned version — e.g. the `collapsible_else_if` clippy lint was added in 1.93 and failed locally but passed CI on an older stable
- Drop the `rust_components` input from `setup-agent-env` — mise installs the full toolchain (rustfmt + clippy included)
- Nightly benchmark also gets `hyperfine` from mise instead of `cargo install`

**Intentionally kept `dtolnay` for:**
- `release.yml` — cross-compilation with target args
- Nightly fuzz job — needs `@nightly` toolchain

## Test plan
- [ ] `checks.yml` jobs pass (build-linux, build-and-test, build-macos)
- [ ] Agent workflows still build (setup-agent-env without `rust_components`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)