### PR TITLE
Include --check-variants in agent validation for mixed cops

### DIFF
--- a/scripts/dispatch_cops.py
+++ b/scripts/dispatch_cops.py
@@ -1748,13 +1748,30 @@ def generate_task(
             step1_text = "1. Read the **Corpus FP/FN Examples** section below first"
         else:
             step1_text = "1. Read the sections below for context"
-        step7_text = (
-            f"7. **Validate against corpus** (REQUIRED before finishing):\n"
-            f"   ```bash\n"
-            f"   python3 scripts/check_cop.py {cop} --rerun --clone --sample 15\n"
-            f"   ```\n"
-            f"   If this reports FP or FN regression, your fix is too broad — narrow it down."
-        )
+        if diverging_variants:
+            # Mixed cop: has default FP/FN AND variant divergence.
+            # Must validate both default and variants to avoid pushing a fix
+            # that passes default but breaks a variant style.
+            step7_text = (
+                f"7. **Validate against corpus** (REQUIRED before finishing):\n"
+                f"   ```bash\n"
+                f"   python3 scripts/check_cop.py {cop} --rerun --clone --sample 15\n"
+                f"   ```\n"
+                f"   **Also validate variant styles** (this cop has non-default style divergence):\n"
+                f"   ```bash\n"
+                f"   python3 scripts/check_cop.py {cop} --rerun --clone --sample 15 "
+                f"--check-variants\n"
+                f"   ```\n"
+                f"   If either reports FP or FN regression, your fix is too broad — narrow it down."
+            )
+        else:
+            step7_text = (
+                f"7. **Validate against corpus** (REQUIRED before finishing):\n"
+                f"   ```bash\n"
+                f"   python3 scripts/check_cop.py {cop} --rerun --clone --sample 15\n"
+                f"   ```\n"
+                f"   If this reports FP or FN regression, your fix is too broad — narrow it down."
+            )
 
     parts.append(f"""## Instructions
 

--- a/tests/python/test_dispatch_cops.py
+++ b/tests/python/test_dispatch_cops.py
@@ -1200,6 +1200,28 @@ def test_generate_task_nonvariant_step7_no_style_flag(tmp_path):
         _teardown_generate_task_env(saved)
 
 
+def test_generate_task_mixed_cop_step7_includes_check_variants(tmp_path):
+    """Mixed cops (default FP/FN + variant divergence) must validate variants too."""
+    saved = _setup_generate_task_env(
+        tmp_path,
+        corpus_overrides={"fp": 5, "fn": 3,
+                          "fp_examples": [{"loc": "r: f.rb:1", "msg": "m"}],
+                          "fn_examples": [{"loc": "r: f.rb:2", "msg": "m"}]},
+        variant_data=[
+            {"style_label": "tabs", "matches": 1000, "fp": 122, "fn": 10,
+             "fp_examples": [], "fn_examples": []},
+        ],
+    )
+    try:
+        task = gct.generate_task("Style/FooBar")
+        workflow_section = task.split("### Workflow")[1].split("### Fixture")[0]
+        assert "--check-variants" in workflow_section
+        # Should also have the default validation
+        assert "check_cop.py Style/FooBar --rerun --clone --sample 15\n" in workflow_section
+    finally:
+        _teardown_generate_task_env(saved)
+
+
 def test_load_variant_data_includes_examples():
     """load_variant_data_for_cop extracts fp_examples and fn_examples."""
     import json


### PR DESCRIPTION
## Summary

- For cops with BOTH default FP/FN AND variant divergence ("mixed cops"), the agent task prompt's step 7 validation only ran `check_cop.py --rerun --clone --sample 15` — default style only, no variant checking
- This caused agents to push fixes that pass default but catastrophically break variants (PR #1916: +20,756 FP on `tabs` style, PR #1950: +23 FP on `comma`, PR #1899: +21 FN on `require_single_line`)
- Now mixed cops include `--check-variants` in step 7, matching variant-only cop behavior

Root cause found by investigating PRs #1962, #1950, #1933, #1899, #1916 — all followed the same pattern: initial fix passes default → CI catches variant regression → repair agent fails (timeout/crash/retry-limit)

## Test plan

- [x] New test: `test_generate_task_mixed_cop_step7_includes_check_variants`
- [x] 547 tests pass
- [x] Verified with `dispatch_cops.py task` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)