### PR TITLE
Fix RSpec/ImplicitExpect should variant

### DIFF
--- a/src/cop/rspec/implicit_expect.rs
+++ b/src/cop/rspec/implicit_expect.rs
@@ -40,26 +40,63 @@ impl Cop for ImplicitExpect {
             None => return,
         };
 
-        if call.receiver().is_some() {
-            return;
-        }
-
         let method_name = call.name().as_slice();
 
         if enforced_style == "should" {
-            // "should" style: flag `is_expected`
-            if method_name == b"is_expected" {
-                let loc = call.location();
-                let (line, column) = source.offset_to_line_col(loc.start_offset());
-                diagnostics.push(self.diagnostic(
-                    source,
-                    line,
-                    column,
-                    "Prefer `should` over `is_expected.to`.".to_string(),
-                ));
+            // "should" style: check .to/.not_to/.to_not calls with is_expected receiver.
+            // Mirrors RuboCop's RESTRICT_ON_SEND = Runners.all, which only triggers on
+            // :to/:not_to/:to_not. The cop then extracts `source_range.source` and looks
+            // it up in ENFORCED_REPLACEMENTS. If the source has unusual whitespace
+            // (multiline or extra spaces), `Hash#fetch` raises KeyError and the offense
+            // is silently skipped — we replicate this quirk.
+            if !matches!(method_name, b"to" | b"not_to" | b"to_not") {
+                return;
             }
+            let receiver = match call.receiver() {
+                Some(r) => r,
+                None => return,
+            };
+            let recv_call = match receiver.as_call_node() {
+                Some(c) => c,
+                None => return,
+            };
+            if recv_call.receiver().is_some() || recv_call.name().as_slice() != b"is_expected" {
+                return;
+            }
+
+            // Verify source text matches exactly (no whitespace anomalies)
+            let is_expected_start = recv_call.location().start_offset();
+            let msg_loc = match call.message_loc() {
+                Some(loc) => loc,
+                None => return,
+            };
+            let source_text = &source.as_bytes()[is_expected_start..msg_loc.end_offset()];
+
+            let (expected_source, replacement): (&[u8], &str) = match method_name {
+                b"to" => (b"is_expected.to", "should"),
+                b"not_to" => (b"is_expected.not_to", "should_not"),
+                b"to_not" => (b"is_expected.to_not", "should_not"),
+                _ => unreachable!(),
+            };
+
+            if source_text != expected_source {
+                return; // Multiline or whitespace anomaly — RuboCop silently skips these
+            }
+
+            let bad = std::str::from_utf8(expected_source).unwrap();
+            let (line, column) = source.offset_to_line_col(is_expected_start);
+            diagnostics.push(self.diagnostic(
+                source,
+                line,
+                column,
+                format!("Prefer `{replacement}` over `{bad}`."),
+            ));
         } else {
             // Default "is_expected" style: flag `should` and `should_not`
+            if call.receiver().is_some() {
+                return;
+            }
+
             if method_name == b"should" {
                 let loc = call.location();
                 let (line, column) = source.offset_to_line_col(loc.start_offset());
@@ -90,38 +127,62 @@ mod tests {
     use super::*;
     crate::cop_fixture_tests!(ImplicitExpect, "cops/rspec/implicit_expect");
 
-    #[test]
-    fn should_style_flags_is_expected() {
-        use crate::cop::CopConfig;
+    fn should_config() -> crate::cop::CopConfig {
         use std::collections::HashMap;
-
-        let config = CopConfig {
+        crate::cop::CopConfig {
             options: HashMap::from([(
                 "EnforcedStyle".into(),
                 serde_yml::Value::String("should".into()),
             )]),
-            ..CopConfig::default()
-        };
+            ..crate::cop::CopConfig::default()
+        }
+    }
+
+    #[test]
+    fn should_style_offense_fixture() {
+        let fixture =
+            include_bytes!("../../../tests/fixtures/cops/rspec/implicit_expect/should_offense.rb");
+        let fixture_str = std::str::from_utf8(fixture).expect("fixture must be valid UTF-8");
+        let source = fixture_str
+            .strip_prefix("# nitrocop-config: EnforcedStyle: should\n")
+            .expect("fixture should start with should config directive");
+        crate::testutil::assert_cop_offenses_full_with_config(
+            &ImplicitExpect,
+            source.as_bytes(),
+            should_config(),
+        );
+    }
+
+    #[test]
+    fn should_style_no_offense_fixture() {
+        let fixture = include_bytes!(
+            "../../../tests/fixtures/cops/rspec/implicit_expect/should_no_offense.rb"
+        );
+        let fixture_str = std::str::from_utf8(fixture).expect("fixture must be valid UTF-8");
+        let source = fixture_str
+            .strip_prefix("# nitrocop-config: EnforcedStyle: should\n")
+            .expect("fixture should start with should config directive");
+        crate::testutil::assert_cop_no_offenses_full_with_config(
+            &ImplicitExpect,
+            source.as_bytes(),
+            should_config(),
+        );
+    }
+
+    #[test]
+    fn should_style_flags_is_expected() {
         let source = b"is_expected.to eq(1)\n";
-        let diags = crate::testutil::run_cop_full_with_config(&ImplicitExpect, source, config);
+        let diags =
+            crate::testutil::run_cop_full_with_config(&ImplicitExpect, source, should_config());
         assert_eq!(diags.len(), 1);
         assert!(diags[0].message.contains("should"));
     }
 
     #[test]
     fn should_style_does_not_flag_should() {
-        use crate::cop::CopConfig;
-        use std::collections::HashMap;
-
-        let config = CopConfig {
-            options: HashMap::from([(
-                "EnforcedStyle".into(),
-                serde_yml::Value::String("should".into()),
-            )]),
-            ..CopConfig::default()
-        };
         let source = b"should eq(1)\n";
-        let diags = crate::testutil::run_cop_full_with_config(&ImplicitExpect, source, config);
+        let diags =
+            crate::testutil::run_cop_full_with_config(&ImplicitExpect, source, should_config());
         assert!(diags.is_empty());
     }
 }

--- a/tests/fixtures/cops/rspec/implicit_expect/should_no_offense.rb
+++ b/tests/fixtures/cops/rspec/implicit_expect/should_no_offense.rb
@@ -1,0 +1,19 @@
+# nitrocop-config: EnforcedStyle: should
+
+# should style is correct — no offense
+should be_truthy
+should_not be_falsy
+
+# Explicit expect is not flagged
+expect(subject).to eq(42)
+expect(something).not_to be_nil
+
+# FP fix: multiline is_expected.to — RuboCop silently skips these
+# (ENFORCED_REPLACEMENTS.fetch fails on whitespace in source range)
+it do
+  is_expected
+    .to be_truthy
+end
+
+# FP fix: space between dot and method name
+it { is_expected. to eq(1) }

--- a/tests/fixtures/cops/rspec/implicit_expect/should_offense.rb
+++ b/tests/fixtures/cops/rspec/implicit_expect/should_offense.rb
@@ -1,0 +1,9 @@
+# nitrocop-config: EnforcedStyle: should
+
+# Standard is_expected.to
+is_expected.to be_truthy
+^^^^^^^^^^^^^^^^^^^ RSpec/ImplicitExpect: Prefer `should` over `is_expected.to`.
+is_expected.to_not be_falsy
+^^^^^^^^^^^^^^^^^^^^^^^ RSpec/ImplicitExpect: Prefer `should_not` over `is_expected.to_not`.
+is_expected.not_to be_falsy
+^^^^^^^^^^^^^^^^^^^^^^^ RSpec/ImplicitExpect: Prefer `should_not` over `is_expected.not_to`.


### PR DESCRIPTION
## Summary
- Fix 8 FP for `EnforcedStyle=should` on `RSpec/ImplicitExpect`
- Root cause: RuboCop checks `.to`/`.not_to`/`.to_not` calls via `RESTRICT_ON_SEND` and extracts `source_range.source` to look up in `ENFORCED_REPLACEMENTS`. When `is_expected.to` spans multiple lines or has extra whitespace (e.g. `is_expected. to`), `Hash#fetch` raises `KeyError` and the offense is silently skipped. Our previous implementation flagged bare `is_expected` calls regardless.
- Now mirrors RuboCop's approach: check `.to`/`.not_to`/`.to_not` calls, verify receiver is bare `is_expected`, and confirm source text matches exactly.

## Test plan
- [x] New variant fixtures pass locally (`should_offense.rb`, `should_no_offense.rb`)
- [ ] CI cop-check-gate passes (including `--check-variants`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)