### PR TITLE
Fix Lint/UselessAssignment rescue body FP suppression

### DIFF
--- a/src/cop/lint/useless_assignment.rs
+++ b/src/cop/lint/useless_assignment.rs
@@ -37,6 +37,17 @@ use crate::parse::source::SourceFile;
 /// assignments for these captures, but they should never be reported as
 /// useless. Fixed by collecting all pattern match target offsets from the
 /// AST and skipping those offsets during offense emission.
+///
+/// ## FP fix: rescue body assignments read in handlers (2026-04-11)
+///
+/// Assignments in begin/rescue/ensure bodies are not useless when the variable
+/// is read in the rescue or ensure handler — if a later overwrite raises, the
+/// handler reads the earlier value. The previous suppression required
+/// `captured_by_block` to be true, which missed the common case of a plain
+/// variable (no block capture) read in a rescue/ensure handler (e.g.,
+/// `code = X; code = Y; rescue; Result.new(code:); end`). Fixed by making the
+/// suppression name-aware: collect variable names read in rescue/ensure handlers
+/// and suppress body writes for those names, regardless of block capture.
 pub struct UselessAssignment;
 
 impl Cop for UselessAssignment {
@@ -92,14 +103,12 @@ impl Cop for UselessAssignment {
             let emit = if conditional_operator_offsets.contains(&candidate.node_offset) {
                 true
             } else if !candidate.engine_used {
-                // Suppress if captured_by_block + inside rescue body: RuboCop's
-                // branch model makes rescue-body references reach earlier
-                // assignments, keeping them alive. Our VF engine doesn't model
-                // rescue branches, so captured_by_block was compensating. After
-                // the used() fix, we must suppress these explicitly.
-                if candidate.captured_by_block
-                    && rescue_body_write_offsets.contains(&candidate.node_offset)
-                {
+                // Suppress if inside rescue body and variable is read in
+                // rescue/ensure handler: RuboCop's VF branch model makes
+                // rescue-body references reach earlier assignments, keeping
+                // them alive. Our VF engine doesn't model rescue branches,
+                // so we suppress these in post-processing.
+                if rescue_body_write_offsets.contains(&candidate.node_offset) {
                     false
                 } else {
                     !should_suppress_multi_rescue_false_positive(&candidate, &rescue_contexts)
@@ -147,8 +156,6 @@ struct AssignmentCandidate {
     node_offset: usize,
     branch_id: Option<usize>,
     engine_used: bool,
-    /// Whether the parent variable is captured by a block/lambda.
-    captured_by_block: bool,
     assignment_states: Vec<AssignmentState>,
     reference_states: Vec<ReferenceState>,
 }
@@ -202,7 +209,6 @@ impl variable_force::VariableForceConsumer for PendingOffenseCollector {
                     node_offset: assignment.node_offset,
                     branch_id: assignment.branch_id,
                     engine_used: assignment.used(variable.captured_by_block),
-                    captured_by_block: variable.captured_by_block,
                     assignment_states: assignment_states.clone(),
                     reference_states: reference_states.clone(),
                 });
@@ -647,42 +653,82 @@ impl<'pr> Visit<'pr> for DoWhileBodyWriteCollector {
 }
 
 // ---------------------------------------------------------------------------
-// FP suppression: captured-by-block assignments inside begin/rescue bodies
+// FP suppression: assignments inside begin/rescue bodies
 // ---------------------------------------------------------------------------
 //
 // RuboCop's VF branch model creates branches for begin/rescue, making the
 // reference walk reach earlier assignments in the rescue-able body. Our VF
-// engine treats the body as unbranched, so `captured_by_block` was previously
-// compensating. After the `used()` fix (which checks `!reassigned`), we must
-// suppress these explicitly to avoid new FPs.
+// engine treats the body as unbranched, so assignments overwritten before the
+// rescue handler look dead even though the handler could read the earlier value.
+//
+// We suppress rescue-body writes when the same variable is read in the
+// rescue/ensure handlers of the same begin block. This matches RuboCop's
+// implicit reachability across the begin/rescue branch boundary.
+
+struct RescueBodyInfo {
+    /// Variable names (with offsets) of writes in the begin body.
+    write_names: Vec<(Vec<u8>, usize)>,
+    /// Variable names read in rescue/ensure handlers.
+    handler_read_names: HashSet<Vec<u8>>,
+}
 
 fn collect_rescue_body_write_offsets(parse_result: &ruby_prism::ParseResult<'_>) -> HashSet<usize> {
     let mut collector = RescueBodyWriteCollector::default();
     collector.visit(&parse_result.node());
-    collector.offsets
+
+    // Build the final offset set: only include writes for variables that
+    // are actually read in the rescue/ensure handlers of the same begin block.
+    let mut offsets = HashSet::new();
+    for info in &collector.begin_blocks {
+        for (name, offset) in &info.write_names {
+            if info.handler_read_names.contains(name) {
+                offsets.insert(*offset);
+            }
+        }
+    }
+    offsets
 }
 
 #[derive(Default)]
 struct RescueBodyWriteCollector {
-    offsets: HashSet<usize>,
+    begin_blocks: Vec<RescueBodyInfo>,
     in_rescue_body: bool,
+    in_handler: bool,
+    current_begin_idx: Option<usize>,
 }
 
 impl<'pr> Visit<'pr> for RescueBodyWriteCollector {
     fn visit_begin_node(&mut self, node: &ruby_prism::BeginNode<'pr>) {
-        // Only mark the body as rescue-able if there IS a rescue clause
-        if node.rescue_clause().is_some() {
-            let was = self.in_rescue_body;
+        if node.rescue_clause().is_some() || node.ensure_clause().is_some() {
+            let idx = self.begin_blocks.len();
+            self.begin_blocks.push(RescueBodyInfo {
+                write_names: Vec::new(),
+                handler_read_names: HashSet::new(),
+            });
+
+            // Visit body as rescue-able
+            let prev_body = self.in_rescue_body;
+            let prev_idx = self.current_begin_idx;
             self.in_rescue_body = true;
+            self.current_begin_idx = Some(idx);
             if let Some(stmts) = node.statements() {
                 for stmt in stmts.body().iter() {
                     self.visit(&stmt);
                 }
             }
-            self.in_rescue_body = was;
-            // Visit rescue/else/ensure normally (not in rescue body context)
+            self.in_rescue_body = prev_body;
+
+            // Visit rescue/else/ensure as handler context
+            let prev_handler = self.in_handler;
+            self.in_handler = true;
             let mut current_rescue = node.rescue_clause();
             while let Some(rescue) = current_rescue {
+                for exception in rescue.exceptions().iter() {
+                    self.visit(&exception);
+                }
+                if let Some(reference) = rescue.reference() {
+                    self.visit(&reference);
+                }
                 if let Some(stmts) = rescue.statements() {
                     for stmt in stmts.body().iter() {
                         self.visit(&stmt);
@@ -704,6 +750,8 @@ impl<'pr> Visit<'pr> for RescueBodyWriteCollector {
                     }
                 }
             }
+            self.in_handler = prev_handler;
+            self.current_begin_idx = prev_idx;
         } else {
             ruby_prism::visit_begin_node(self, node);
         }
@@ -711,7 +759,11 @@ impl<'pr> Visit<'pr> for RescueBodyWriteCollector {
 
     fn visit_local_variable_write_node(&mut self, node: &ruby_prism::LocalVariableWriteNode<'pr>) {
         if self.in_rescue_body {
-            self.offsets.insert(node.location().start_offset());
+            if let Some(idx) = self.current_begin_idx {
+                let offset = node.location().start_offset();
+                let name = node.name().as_slice().to_vec();
+                self.begin_blocks[idx].write_names.push((name, offset));
+            }
         }
         ruby_prism::visit_local_variable_write_node(self, node);
     }
@@ -721,7 +773,21 @@ impl<'pr> Visit<'pr> for RescueBodyWriteCollector {
         node: &ruby_prism::LocalVariableTargetNode<'pr>,
     ) {
         if self.in_rescue_body {
-            self.offsets.insert(node.location().start_offset());
+            if let Some(idx) = self.current_begin_idx {
+                let offset = node.location().start_offset();
+                let name = node.name().as_slice().to_vec();
+                self.begin_blocks[idx].write_names.push((name, offset));
+            }
+        }
+    }
+
+    fn visit_local_variable_read_node(&mut self, node: &ruby_prism::LocalVariableReadNode<'pr>) {
+        if self.in_handler {
+            if let Some(idx) = self.current_begin_idx {
+                self.begin_blocks[idx]
+                    .handler_read_names
+                    .insert(node.name().as_slice().to_vec());
+            }
         }
     }
 }

--- a/tests/fixtures/cops/lint/useless_assignment/no_offense.rb
+++ b/tests/fixtures/cops/lint/useless_assignment/no_offense.rb
@@ -556,3 +556,26 @@ def inline_rescue_assign
   raise "Invalid #{err}" if err
   [red_low, yellow_low, yellow_high, red_high]
 end
+
+# FP fix: assignment in implicit-rescue method body, variable read in rescue handler.
+# If `extract_code` raises, the rescue handler reads `code` (via `code:` shorthand)
+# with the value from the first assignment. Not useless.
+def get_embedded_sql_answer(text)
+  code = text[/^SQLQuery: (.*)/, 1]
+  code = extract_code(text)
+  Boxcars.debug code, :yellow
+  output = clean_up_output(code)
+  Result.new(status: :ok, answer: output, code: code)
+rescue StandardError => e
+  Result.new(status: :error, answer: nil, explanation: e.message, code: code)
+end
+
+# FP fix: assignment before ensure block, variable read in ensure.
+# If `start(...)` raises, the ensure block reads `obj` with the initial value.
+def call_target(target_num)
+  obj = {}
+  obj = start(target_num: target_num)
+  process(obj)
+ensure
+  cleanup(obj)
+end


### PR DESCRIPTION
## Summary
- Fix FPs for `Lint/UselessAssignment` where assignments in begin/rescue/ensure bodies are flagged as useless despite being read in rescue/ensure handlers
- Root cause: the previous rescue-body FP suppression required `captured_by_block` to be true, missing the common pattern where a plain variable (no block capture) is written in a begin body and read in a rescue/ensure handler (e.g., `code = X; code = Y; rescue; Result.new(code:); end`)
- Fix: made the suppression name-aware — `RescueBodyWriteCollector` now tracks variable names read in rescue/ensure handlers for each begin block, suppressing body writes only when the variable is read in a handler (regardless of block capture)
- This is more precise than the old approach: it avoids both over-suppression (suppressing writes for variables NOT read in handlers) and under-suppression (requiring `captured_by_block`)

## Test plan
- [x] New no-offense fixtures pass (implicit-rescue method with handler read, ensure block with handler read)
- [x] All existing offense and no-offense fixtures still pass
- [ ] CI cop-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)