### PR TITLE
Fix Lint/ShadowingOuterLocalVariable: def inside conditional FN

### DIFF
--- a/src/cop/lint/shadowing_outer_local_variable.rs
+++ b/src/cop/lint/shadowing_outer_local_variable.rs
@@ -1013,12 +1013,20 @@ impl<'pr> Visit<'pr> for ContextCollector {
             }
         }
 
+        // Clear conditional branch context: def creates a hard scope boundary
+        // for local variables. Conditional context from enclosing if/unless/case
+        // should not leak into the def body, or blocks inside the def would
+        // incorrectly suppress shadowing via block_cond_parent_suppresses.
+        let saved_cond_stack = std::mem::take(&mut self.conditional_branch_stack);
+        let saved_inherited = self.inherited_cond_branch.take();
         if let Some(parameters) = node.parameters() {
             self.visit_parameters_node(&parameters);
         }
         if let Some(body) = node.body() {
             self.visit(&body);
         }
+        self.conditional_branch_stack = saved_cond_stack;
+        self.inherited_cond_branch = saved_inherited;
     }
 
     fn visit_class_node(&mut self, node: &ruby_prism::ClassNode<'pr>) {

--- a/tests/fixtures/cops/lint/shadowing_outer_local_variable/offense.rb
+++ b/tests/fixtures/cops/lint/shadowing_outer_local_variable/offense.rb
@@ -569,3 +569,35 @@ def allowed_to_query(user, permission)
     end
   end
 end
+
+# FN fix: def inside conditional — the conditional branch context should not
+# leak through the def scope boundary. Block params inside the def that shadow
+# method params should still be flagged.
+unless Kernel.respond_to?(:require_relative)
+  def require_relative(path)
+    $:.each do |path|
+                ^^^^ Lint/ShadowingOuterLocalVariable: Shadowing outer local variable - `path`.
+      path += '/'
+    end
+  end
+end
+
+# Same pattern with if
+if RUBY_VERSION < '2.0'
+  def my_method(data)
+    data.map do |data|
+                 ^^^^ Lint/ShadowingOuterLocalVariable: Shadowing outer local variable - `data`.
+      data.to_s
+    end
+  end
+end
+
+# def self.foo inside conditional
+if defined?(Net::HTTP)
+  def self.simulate(http)
+    http.start do |http|
+                   ^^^^ Lint/ShadowingOuterLocalVariable: Shadowing outer local variable - `http`.
+      http.request
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fix FNs for `Lint/ShadowingOuterLocalVariable` where block params inside a `def` wrapped in a conditional (`if`/`unless`/`case`) fail to flag shadowing
- Root cause: the `ContextCollector`'s conditional branch stack was not cleared when entering `def` bodies. When a `def` is inside a conditional, the conditional context leaked through the hard scope boundary, causing `block_cond_parent_suppresses` to incorrectly suppress shadowing for blocks inside the def.
- Fix: save/restore the conditional branch stack and inherited conditional context around def parameter and body visits, matching the pattern used by `visit_block_node` and `visit_lambda_node`.

Example:
```ruby
unless Kernel.respond_to?(:require_relative)
  def require_relative(path)
    $:.each do |path|    # should flag: path shadows method param
    end
  end
end
```

## Test plan
- [x] New offense fixtures pass (def inside unless, if, and def self. inside if)
- [x] All existing offense and no-offense fixtures still pass
- [ ] CI cop-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)