### PR TITLE
Fix Layout/MultilineMethodCallIndentation indented_relative_to_receiver variant

### DIFF
--- a/src/cop/layout/multiline_method_call_indentation.rs
+++ b/src/cop/layout/multiline_method_call_indentation.rs
@@ -179,6 +179,12 @@ impl Cop for MultilineMethodCallIndentation {
     }
 }
 
+enum MsgStyle {
+    Aligned,
+    Indented,
+    ReceiverRelative,
+}
+
 struct ChainVisitor<'a> {
     cop: &'a MultilineMethodCallIndentation,
     source: &'a SourceFile,
@@ -246,10 +252,15 @@ impl ChainVisitor<'_> {
             return;
         }
 
-        // Track whether to use aligned or indented message format
-        let (expected, use_aligned_msg) = match self.style {
-            "indented" | "indented_relative_to_receiver" => {
-                (self.expected_indented(call_node, &receiver), false)
+        // Compute expected column and message style based on EnforcedStyle
+        let (expected, msg_style) = match self.style {
+            "indented" => (
+                self.expected_indented(call_node, &receiver),
+                MsgStyle::Indented,
+            ),
+            "indented_relative_to_receiver" => {
+                let col = self.expected_relative_to_receiver(call_node, &receiver);
+                (col, MsgStyle::ReceiverRelative)
             }
             _ => {
                 // "aligned" (default)
@@ -260,21 +271,26 @@ impl ChainVisitor<'_> {
                     rhs_col,
                     is_trailing_dot,
                 ) {
-                    Some(col) => (col, true),
+                    Some(col) => (col, MsgStyle::Aligned),
                     None => {
                         // No alignment base found — fall back to indented behavior,
                         // matching RuboCop's `indentation(lhs) + correct_indentation(node)`
-                        (self.expected_indented(call_node, &receiver), false)
+                        (
+                            self.expected_indented(call_node, &receiver),
+                            MsgStyle::Indented,
+                        )
                     }
                 }
             }
         };
 
         if rhs_col != expected {
-            let msg = if use_aligned_msg {
-                self.aligned_message(call_node, &receiver, is_trailing_dot)
-            } else {
-                self.indented_message(call_node, &receiver, rhs_col)
+            let msg = match msg_style {
+                MsgStyle::Aligned => self.aligned_message(call_node, &receiver, is_trailing_dot),
+                MsgStyle::ReceiverRelative => {
+                    self.receiver_relative_message(call_node, &receiver, is_trailing_dot)
+                }
+                MsgStyle::Indented => self.indented_message(call_node, &receiver, rhs_col),
             };
             self.diagnostics
                 .push(self.cop.diagnostic(self.source, rhs_line, rhs_col, msg));
@@ -292,6 +308,32 @@ impl ChainVisitor<'_> {
         let base_indent = indentation_of(base_line_bytes);
         let kw_extra = keyword_extra_indent(self.source, call_node, self.width);
         base_indent + self.width + kw_extra
+    }
+
+    /// RuboCop's `receiver_alignment_base` + `extra_indentation` for
+    /// `indented_relative_to_receiver` style.
+    ///
+    /// Returns: expected column = base_col + effective_width.
+    ///
+    /// The base is determined by `find_hash_method_base_col` (for hash/paren
+    /// receivers) or `find_chain_root_col` (the chain root receiver).
+    /// No keyword extra indent — `@base` is always set for this style.
+    ///
+    /// Width is adjusted for splat (`*`) and kwsplat (`**`) — RuboCop's
+    /// `extra_indentation` subtracts the operator length.
+    fn expected_relative_to_receiver(
+        &self,
+        _call_node: &ruby_prism::CallNode<'_>,
+        receiver: &ruby_prism::Node<'_>,
+    ) -> usize {
+        let splat_adj = splat_operator_length(self.source, receiver);
+        let effective_width = self.width.saturating_sub(splat_adj);
+
+        if let Some(base_col) = find_hash_method_base_col(self.source, receiver) {
+            base_col + effective_width
+        } else {
+            find_chain_root_col(self.source, receiver) + effective_width
+        }
     }
 
     fn expected_aligned(
@@ -449,6 +491,34 @@ impl ChainVisitor<'_> {
             "Use {} (not {}) spaces for indentation of a chained method call.",
             self.width,
             rhs_col.saturating_sub(chain_indent)
+        )
+    }
+
+    /// Message for `indented_relative_to_receiver` style.
+    /// Format: "Indent `.method` N spaces more than `base_source` on line L."
+    fn receiver_relative_message(
+        &self,
+        call_node: &ruby_prism::CallNode<'_>,
+        receiver: &ruby_prism::Node<'_>,
+        is_trailing_dot: bool,
+    ) -> String {
+        let selector_str = if is_trailing_dot {
+            // For trailing dot, the selector (method name) is the RHS
+            let name = call_node.name().as_slice();
+            std::str::from_utf8(name).unwrap_or("?").to_string()
+        } else if call_node.message_loc().is_some() {
+            let name = call_node.name().as_slice();
+            format!(".{}", std::str::from_utf8(name).unwrap_or("?"))
+        } else {
+            // Implicit call (proc call) — `a\n  .(args)`
+            ".(".to_string()
+        };
+
+        let (base_name, base_line) = find_receiver_relative_base_description(self.source, receiver);
+
+        format!(
+            "Indent `{selector_str}` {} spaces more than `{base_name}` on line {base_line}.",
+            self.width
         )
     }
 }
@@ -1062,6 +1132,126 @@ fn find_chain_root_offset(node: &ruby_prism::Node<'_>) -> usize {
     node.location().start_offset()
 }
 
+/// Detect if the chain root is preceded by a splat (`*`) or kwsplat (`**`)
+/// operator on the same line. Returns the operator length (0, 1, or 2).
+///
+/// RuboCop's `extra_indentation` for `indented_relative_to_receiver` subtracts
+/// the operator length from the configured indentation width.
+fn splat_operator_length(source: &SourceFile, receiver: &ruby_prism::Node<'_>) -> usize {
+    let root_offset = find_chain_root_offset(receiver);
+    if root_offset == 0 {
+        return 0;
+    }
+    let bytes = source.as_bytes();
+    if bytes[root_offset - 1] == b'*' {
+        if root_offset >= 2 && bytes[root_offset - 2] == b'*' {
+            return 2; // **expr
+        }
+        return 1; // *expr
+    }
+    0
+}
+
+/// RuboCop's `find_hash_method_base_in_receiver_chain` for
+/// `indented_relative_to_receiver` style.
+///
+/// Walks the receiver chain downward. For each call node, checks if its
+/// receiver is:
+/// 1. A hash literal (`HashNode`) → return that call's dot column
+/// 2. A parenthesized expression (`ParenthesesNode`) where the dot is on
+///    the same line as the closing paren → return that call's dot column
+///
+/// This handles patterns like:
+/// ```ruby
+/// { a: 1, b: 2 }.keys     # base = `.keys` dot
+///                  .first  # indented relative to `.keys`
+///
+/// (date_columns + cols).uniq    # base = `.uniq` dot
+///                        .each  # indented relative to `.uniq`
+/// ```
+fn find_hash_method_base_col(source: &SourceFile, node: &ruby_prism::Node<'_>) -> Option<usize> {
+    let call = node.as_call_node()?;
+    let recv = call.receiver()?;
+
+    // Check if receiver is a hash literal (HashNode or KeywordHashNode —
+    // RuboCop's `hash_type?` matches both)
+    if recv.as_hash_node().is_some() || recv.as_keyword_hash_node().is_some() {
+        if let Some(dot_loc) = call.call_operator_loc() {
+            let (_, dot_col) = source.offset_to_line_col(dot_loc.start_offset());
+            return Some(dot_col);
+        }
+    }
+    // Check if receiver is a parenthesized expression with dot on
+    // the same line as the closing paren
+    if recv.as_parentheses_node().is_some() {
+        let (recv_end_line, _) = source.offset_to_line_col(recv.location().end_offset());
+        if let Some(dot_loc) = call.call_operator_loc() {
+            let (dot_line, dot_col) = source.offset_to_line_col(dot_loc.start_offset());
+            if dot_line == recv_end_line {
+                return Some(dot_col);
+            }
+        }
+    }
+
+    // Recurse into receiver chain
+    find_hash_method_base_col(source, &recv)
+}
+
+/// Build base description for `indented_relative_to_receiver` messages.
+///
+/// Returns (base_source_text, base_line) matching RuboCop's `base_source`
+/// which is `@base.source[/[^\n]*/]` — the first line of the base range.
+///
+/// For hash/paren chains, the base is the dot+selector (e.g., `.keys`).
+/// For normal chains, the base is the chain root (e.g., `Thing`).
+fn find_receiver_relative_base_description(
+    source: &SourceFile,
+    receiver: &ruby_prism::Node<'_>,
+) -> (String, usize) {
+    // Check for hash/paren method base first
+    if let Some((desc, line)) = find_hash_method_base_description(source, receiver) {
+        return (desc, line);
+    }
+
+    // Normal chain: base is the chain root receiver
+    find_chain_root_description(source, receiver)
+}
+
+/// Build description for hash/paren method base.
+/// Walks receiver chain looking for hash/paren receivers (same logic as
+/// `find_hash_method_base_col`), returns the dot+selector text.
+fn find_hash_method_base_description(
+    source: &SourceFile,
+    node: &ruby_prism::Node<'_>,
+) -> Option<(String, usize)> {
+    let call = node.as_call_node()?;
+    let recv = call.receiver()?;
+
+    let is_hash = recv.as_hash_node().is_some() || recv.as_keyword_hash_node().is_some();
+    let is_paren_same_line = if recv.as_parentheses_node().is_some() {
+        if let Some(dot_loc) = call.call_operator_loc() {
+            let (recv_end_line, _) = source.offset_to_line_col(recv.location().end_offset());
+            let (dot_line, _) = source.offset_to_line_col(dot_loc.start_offset());
+            dot_line == recv_end_line
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    if is_hash || is_paren_same_line {
+        let name = std::str::from_utf8(call.name().as_slice()).unwrap_or("?");
+        if let Some(dot_loc) = call.call_operator_loc() {
+            let (line, _) = source.offset_to_line_col(dot_loc.start_offset());
+            return Some((format!(".{name}"), line));
+        }
+    }
+
+    // Recurse into receiver chain
+    find_hash_method_base_description(source, &recv)
+}
+
 /// Walk backwards from a given line to find the first line that does NOT
 /// start with a continuation dot.
 fn find_non_continuation_ancestor_line(source: &SourceFile, start_line: usize) -> usize {
@@ -1212,6 +1402,11 @@ mod tests {
     crate::cop_fixture_tests!(
         MultilineMethodCallIndentation,
         "cops/layout/multiline_method_call_indentation"
+    );
+    crate::cop_variant_fixture_tests!(
+        MultilineMethodCallIndentation,
+        "cops/layout/multiline_method_call_indentation",
+        indented_relative_to_receiver
     );
 
     #[test]

--- a/tests/fixtures/cops/layout/multiline_method_call_indentation/no_offense.indented_relative_to_receiver.rb
+++ b/tests/fixtures/cops/layout/multiline_method_call_indentation/no_offense.indented_relative_to_receiver.rb
@@ -1,0 +1,154 @@
+# nitrocop-config: EnforcedStyle: indented_relative_to_receiver
+# Basic chain: receiver at col 0, dot at col 2
+a
+  .b
+  .c
+
+# Chain in method body
+def foo
+  query
+    .select('foo')
+    .limit(1)
+end
+
+# Assignment: receiver-relative indent
+myvariable = Thing
+               .a
+               .b
+               .c
+
+# Multi-line assignment (= on previous line)
+result =
+  int_part
+    .abs
+    .to_s
+
+# obj.attr assignment with newline after =
+obj.attr =
+  int_part
+    .abs
+    .to_s
+
+# Operation RHS: receiver-relative indent
+1 + a
+      .b
+      .c
+
+# Hash access receiver
+hash[:key]
+  .do_something
+
+# Trailing dot: proper indent
+a.
+  b
+
+# Trailing dot: 3rd line same indent as 2nd
+a.
+  b.
+  c
+
+# RSpec block chain continuation
+expect { Foo.new }.to change { Bar.count }
+                        .from(1).to(2)
+
+# Splat with method chain (width adjusted: 2-1=1)
+[
+  *foo
+    .bar(
+      arg)
+]
+
+# Double splat with method chain (width adjusted: 2-2=0)
+[
+  **foo
+    .bar(
+      arg)
+]
+
+# Splat with block chain
+[
+  *foo
+    .bar { |arg| baz(arg) }
+]
+
+# Single-line block chain
+(0..foo).bar { baz }
+          .qux { quux }
+
+(0..foo).bar { baz }
+          .qux
+
+(0..foo).bar
+          .qux { quux }
+
+# Hash literal receiver: indent relative to first dot+selector
+{ a: 1, b: 2 }.keys
+                .first
+
+# Parenthesized expression receiver
+def run
+  (date_columns + candidate_columns).uniq
+                                      .select { |cn| castable?(cn) }
+                                      .each { |cn| cast(cn) }
+end
+
+# Multiline parens: receiver-relative to first dot+selector
+(a +
+ b).foo
+     .bar
+
+# Multi-dot chain in hash pair value passed to method
+method(key: value.foo.bar
+              .baz)
+
+# Indented methods in LHS of []= assignment
+a
+  .b[c] = 0
+
+# Indented methods inside and outside a block
+a = b.map do |c|
+  c
+    .b
+    .d do
+      x
+        .y
+    end
+end
+
+# Indentation relative to first receiver
+node
+  .children.map { |n| string_source(n) }.compact
+  .any? { |s| preferred.any? { |d| s.include?(d) } }
+
+# Indented methods in ordinary statement (trailing dot)
+a.
+  b
+
+# No extra indentation of third line (trailing dot)
+a.
+  b.
+  c
+
+# Indented methods in for body
+for x in a
+  something.
+    something_else
+end
+
+# Alignment inside a grouped expression
+(a.
+ b)
+
+# An expression where the first method spans multiple lines
+subject.each do |item|
+  result = resolve(locale) and return result
+end.a
+
+# Any indentation of parameters to #[]
+payment = Models::IncomingPayments[
+        id:      input['incoming-payment-id'],
+           user_id: @user[:id]]
+
+# Correctly indented method after hash access
+hash[:key]
+  .do_something

--- a/tests/fixtures/cops/layout/multiline_method_call_indentation/offense.indented_relative_to_receiver.rb
+++ b/tests/fixtures/cops/layout/multiline_method_call_indentation/offense.indented_relative_to_receiver.rb
@@ -1,0 +1,63 @@
+# nitrocop-config: EnforcedStyle: indented_relative_to_receiver
+# nitrocop-expect: 3:1 Layout/MultilineMethodCallIndentation: Indent `.b` 2 spaces more than `a` on line 2.
+# nitrocop-expect: 7:0 Layout/MultilineMethodCallIndentation: Indent `b` 2 spaces more than `a` on line 6.
+# nitrocop-expect: 11:3 Layout/MultilineMethodCallIndentation: Indent `b` 2 spaces more than `a` on line 10.
+# nitrocop-expect: 16:4 Layout/MultilineMethodCallIndentation: Indent `c` 2 spaces more than `a` on line 14.
+# nitrocop-expect: 21:1 Layout/MultilineMethodCallIndentation: Indent `b` 2 spaces more than `a` on line 20.
+# Basic: 1 space indent instead of 2
+a
+ .b
+
+# Trailing dot: no indent
+a.
+b
+
+# Trailing dot: 3 spaces instead of 2
+a.
+   b
+
+# 3rd line extra indentation (trailing dot)
+a.
+  b.
+    c
+
+# Array item trailing dot
+[
+ a.
+ b
+]
+
+# Hash pair value: shifted left
+# nitrocop-expect: 28:1 Layout/MultilineMethodCallIndentation: Indent `.veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long_method_name` 2 spaces more than `VeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeryLongClassName` on line 27.
+def foo
+  bar(
+    key: VeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeryLongClassName
+ .veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long_method_name
+  )
+end
+
+# Hash pair value: shifted right
+# nitrocop-expect: 36:16 Layout/MultilineMethodCallIndentation: Indent `.veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long_method_name` 2 spaces more than `VeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeryLongClassName` on line 35.
+def foo
+  bar(
+    key: VeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeryLongClassName
+                .veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long_method_name
+  )
+end
+
+# Unary operator receiver
+# nitrocop-expect: 43:2 Layout/MultilineMethodCallIndentation: Indent `.nil?` 2 spaces more than `0` on line 42.
+def foo
+  !0
+  .nil?
+end
+
+# Hash literal receiver: misaligned (dot of .keys is at col 14, expect col 16)
+# nitrocop-expect: 48:14 Layout/MultilineMethodCallIndentation: Indent `.first` 2 spaces more than `.keys` on line 47.
+{ a: 1, b: 2 }.keys
+              .first
+
+# Proc call without selector
+# nitrocop-expect: 52:1 Layout/MultilineMethodCallIndentation: Indent `.(` 2 spaces more than `a` on line 51.
+a
+ .(args)


### PR DESCRIPTION
## Summary
- Implement proper `indented_relative_to_receiver` style for `Layout/MultilineMethodCallIndentation`
- Previously treated identically to `indented` (using `line_indent + width`), now correctly uses `receiver_col + width` matching RuboCop's `receiver_alignment_base`
- Adds hash/paren receiver detection (`find_hash_method_base_col`), splat width adjustment, and receiver-relative message format

## Changes
- Split style dispatch in `check_call` so `indented_relative_to_receiver` has its own path
- New `expected_relative_to_receiver` method: base = chain root column (or hash/paren method base dot column) + width
- New `find_hash_method_base_col`: walks receiver chain detecting `HashNode`/`KeywordHashNode`/`ParenthesesNode` receivers (mirrors RuboCop's `find_hash_method_base_in_receiver_chain`)
- New `splat_operator_length`: adjusts width for `*`/`**` operators (mirrors RuboCop's `extra_indentation`)
- New `receiver_relative_message`: "Indent `.x` N spaces more than `base` on line L."
- Variant fixture tests covering: basic chains, trailing dot, assignment context, hash/paren receivers, splat, unary operators, proc calls

## Context
Corpus baseline: 2,372 FP, 22,142 FN for this variant. The prior attempt (PR #2163) regressed +715 FP / +4446 FN because it didn't implement hash/paren base detection and may have affected shared code paths. This implementation keeps the `indented` path completely untouched.

## Test plan
- [x] All 6,055 lib tests pass (including all existing default/aligned fixtures)
- [x] Both variant fixtures (offense + no_offense) pass
- [x] `prism_pitfalls` integration test passes (KeywordHashNode handled)
- [x] Full release test suite: 0 failures
- [ ] CI cop-check-gate passes (including `--check-variants`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)