### PR TITLE
Bump claude backends to Opus 4.7, shift effort tiers up one notch

### DIFF
--- a/.agents/skills/repair-variant/SKILL.md
+++ b/.agents/skills/repair-variant/SKILL.md
@@ -171,7 +171,7 @@ cargo test --release -p nitrocop --lib -- cop::<dept>::<cop_name_snake>
 git add src/cop/<dept>/<cop_name>.rs tests/fixtures/cops/<dept>/<cop_name>/
 git commit -m "Fix <variant> variant: <brief description>
 
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 git push origin HEAD
 ```
 

--- a/.claude/skills/fix-department/SKILL.md
+++ b/.claude/skills/fix-department/SKILL.md
@@ -345,7 +345,7 @@ if the prompt/examples require local corpus source context.
 
    <one-line description of what was wrong>
 
-   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+   Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
    ```
    Stage only files for this cop fix. Do not include unrelated modified files.
 

--- a/.claude/skills/repair-variant/SKILL.md
+++ b/.claude/skills/repair-variant/SKILL.md
@@ -171,7 +171,7 @@ cargo test --release -p nitrocop --lib -- cop::<dept>::<cop_name_snake>
 git add src/cop/<dept>/<cop_name>.rs tests/fixtures/cops/<dept>/<cop_name>/
 git commit -m "Fix <variant> variant: <brief description>
 
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 git push origin HEAD
 ```
 

--- a/scripts/workflows/resolve_backend.py
+++ b/scripts/workflows/resolve_backend.py
@@ -101,7 +101,7 @@ def claude_backend(strength: str, effort: str, display_label: str, model_label: 
     return {
         "family": "claude",
         "strength": strength,
-        "model": "claude-opus-4-6",
+        "model": "claude-opus-4-7",
         "reasoning_effort": effort,
         "display_label": display_label,
         "model_label": model_label,
@@ -116,14 +116,14 @@ def claude_backend(strength: str, effort: str, display_label: str, model_label: 
         "log_pattern": "~/.claude/projects/**/*.jsonl",
         "run_cmd": (
             f'claude -p --dangerously-skip-permissions '
-            f'--model claude-opus-4-6 --effort {effort} '
+            f'--model claude-opus-4-7 --effort {effort} '
             f'--output-format json '
             f'"$(cat "$FINAL_TASK_FILE")" '
             f'> "$AGENT_RESULT_FILE" '
             f'2> >(tee "$AGENT_LOG_FILE" >&2) || true'
         ),
         "env": {
-            "ANTHROPIC_MODEL": "claude-opus-4-6",
+            "ANTHROPIC_MODEL": "claude-opus-4-7",
             "API_TIMEOUT_MS": "300000",
             "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
         },
@@ -133,15 +133,15 @@ def claude_backend(strength: str, effort: str, display_label: str, model_label: 
     }
 
 
-CLAUDE_NORMAL_BACKEND = claude_backend("normal", "medium", "claude / normal", "Claude Opus 4.6 (medium)")
-CLAUDE_HARD_BACKEND = claude_backend("hard", "high", "claude / hard", "Claude Opus 4.6 (high)")
+CLAUDE_NORMAL_BACKEND = claude_backend("normal", "high", "claude / normal", "Claude Opus 4.7 (high)")
+CLAUDE_HARD_BACKEND = claude_backend("hard", "xhigh", "claude / hard", "Claude Opus 4.7 (xhigh)")
 
 
 def claude_oauth_backend(strength: str, effort: str, display_label: str, model_label: str) -> dict:
     return {
         "family": "claude-oauth",
         "strength": strength,
-        "model": "claude-opus-4-6",
+        "model": "claude-opus-4-7",
         "reasoning_effort": effort,
         "display_label": display_label,
         "model_label": model_label,
@@ -156,7 +156,7 @@ def claude_oauth_backend(strength: str, effort: str, display_label: str, model_l
         "log_pattern": "~/.claude/projects/**/*.jsonl",
         "run_cmd": "",
         "env": {
-            "ANTHROPIC_MODEL": "claude-opus-4-6",
+            "ANTHROPIC_MODEL": "claude-opus-4-7",
             "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
         },
         "secrets": {
@@ -169,10 +169,10 @@ CODEX_54_HIGH_BACKEND = codex_backend("gpt-5.4", "high", "normal")
 CODEX_54_XHIGH_BACKEND = codex_backend("gpt-5.4", "xhigh", "hard")
 
 CLAUDE_OAUTH_NORMAL_BACKEND = claude_oauth_backend(
-    "normal", "medium", "claude-oauth / normal", "Claude Opus 4.6 (OAuth, medium)",
+    "normal", "high", "claude-oauth / normal", "Claude Opus 4.7 (OAuth, high)",
 )
 CLAUDE_OAUTH_HARD_BACKEND = claude_oauth_backend(
-    "hard", "high", "claude-oauth / hard", "Claude Opus 4.6 (OAuth, high)",
+    "hard", "xhigh", "claude-oauth / hard", "Claude Opus 4.7 (OAuth, xhigh)",
 )
 
 

--- a/tests/python/workflows/test_cop_fix_lifecycle.py
+++ b/tests/python/workflows/test_cop_fix_lifecycle.py
@@ -351,7 +351,7 @@ def test_cleanup_failure_closes_pr_then_deletes_branch_and_requeues_issue(tmp_pa
             "--issue-number", "376",
             "--repo", "6/nitrocop",
             "--backend-label", "claude-oauth / hard",
-            "--model-label", "Claude Opus 4.6 (OAuth, high)",
+            "--model-label", "Claude Opus 4.7 (OAuth, xhigh)",
             "--mode", "fix",
             "--run-url", "https://github.com/6/nitrocop/actions/runs/23699434606",
         ])
@@ -407,7 +407,7 @@ def test_cleanup_failure_includes_agent_findings_when_result_file_exists(tmp_pat
             "--issue-number", "376",
             "--repo", "6/nitrocop",
             "--backend-label", "claude-oauth / hard",
-            "--model-label", "Claude Opus 4.6 (OAuth, high)",
+            "--model-label", "Claude Opus 4.7 (OAuth, xhigh)",
             "--mode", "fix",
             "--run-url", "https://github.com/6/nitrocop/actions/runs/23699434606",
         ])
@@ -451,7 +451,7 @@ def test_cleanup_failure_warns_and_keeps_issue_state_when_pr_close_fails(tmp_pat
             "--issue-number", "376",
             "--repo", "6/nitrocop",
             "--backend-label", "claude-oauth / hard",
-            "--model-label", "Claude Opus 4.6 (OAuth, high)",
+            "--model-label", "Claude Opus 4.7 (OAuth, xhigh)",
             "--mode", "fix",
             "--run-url", "https://github.com/6/nitrocop/actions/runs/23699434606",
         ])

--- a/tests/python/workflows/test_resolve_backend.py
+++ b/tests/python/workflows/test_resolve_backend.py
@@ -94,8 +94,8 @@ def test_claude_oauth_normal():
     assert "CLAUDE_CODE_OAUTH_TOKEN" in config["setup_cmd"]
     assert "ANTHROPIC_API_KEY" not in config["setup_cmd"]
     assert "claude.ai/install.sh" not in config["setup_cmd"]
-    assert config["env"]["ANTHROPIC_MODEL"] == "claude-opus-4-6"
-    assert config["reasoning_effort"] == "medium"
+    assert config["env"]["ANTHROPIC_MODEL"] == "claude-opus-4-7"
+    assert config["reasoning_effort"] == "high"
     assert "CLAUDE_CODE_OAUTH_TOKEN" in config["secrets"]
 
 
@@ -103,9 +103,9 @@ def test_claude_oauth_hard():
     config = resolve_backend.resolve("claude-oauth-hard")
     assert config["cli"] == "claude-action"
     assert config["action"] is True
-    assert config["env"]["ANTHROPIC_MODEL"] == "claude-opus-4-6"
-    assert config["reasoning_effort"] == "high"
-    assert "Opus 4.6" in config["model_label"]
+    assert config["env"]["ANTHROPIC_MODEL"] == "claude-opus-4-7"
+    assert config["reasoning_effort"] == "xhigh"
+    assert "Opus 4.7" in config["model_label"]
 
 
 def test_choose_claude_oauth():


### PR DESCRIPTION
## Summary
- Swap \`claude-opus-4-6\` → \`claude-opus-4-7\` in both API-key and OAuth claude backends (model field, \`ANTHROPIC_MODEL\` env var, \`--model\` arg in run_cmd).
- Shift effort tiers up one notch so they mirror codex's high/xhigh spacing:
  - \`claude-normal\`: medium → high
  - \`claude-hard\`: high → xhigh
  - \`claude-oauth-normal\`: medium → high
  - \`claude-oauth-hard\`: high → xhigh
- Codex remains the overall batch-dispatch default — only the claude backends change.
- Update commit-trailer co-authors in \`.claude/skills/\` and \`.agents/skills/\` SKILL.md files from Opus 4.6 → 4.7.
- \`anthropics/claude-code-action@v1\` is already pinned to the latest commit (v1 and v1.0.99 both point to \`c3d45e8\`, bundling Claude Code 2.1.112) — no bump needed.

## Test plan
- [x] \`uv run ruff check\` on modified files — passes
- [x] \`uv run pytest tests/python/workflows/test_resolve_backend.py tests/python/workflows/test_cop_fix_lifecycle.py\` — 55 passed
- [ ] First \`agent-cop-fix\` dispatch with \`backend=claude\` on this branch confirms the xhigh effort value is accepted by the claude CLI