### PR TITLE
Fix RSpec/LeakyLocalVariable FP for rightward pattern-match bindings

### DIFF
--- a/src/cop/variable_force/engine.rs
+++ b/src/cop/variable_force/engine.rs
@@ -970,9 +970,11 @@ impl<'pr> Visit<'pr> for Engine<'_> {
 
     fn visit_match_required_node(&mut self, node: &ruby_prism::MatchRequiredNode<'pr>) {
         // `expr => pattern` creates local variables that remain visible in the
-        // surrounding scope. Declare them before visiting descendants so later
-        // reads in the same method can resolve them through VariableTable.
-        declare_and_assign_pattern_targets(self, &node.pattern());
+        // surrounding scope. RuboCop's `process_pattern_match_variable` only
+        // declares these — it does not record an assignment — so cops that
+        // iterate `variable.assignments` (e.g. RSpec/LeakyLocalVariable) stay
+        // quiet on pattern-match-only bindings. Match that behavior.
+        declare_pattern_targets(self, &node.pattern());
         ruby_prism::visit_match_required_node(self, node);
     }
 
@@ -1350,7 +1352,7 @@ fn predicate_has_lvar_write(node: &ruby_prism::Node<'_>) -> bool {
 /// can find the variable before the pattern target node is visited. Without the
 /// generic `visit_local_variable_target_node` handler, this function must also
 /// create assignments (not just declarations) for pattern match variables.
-fn declare_and_assign_pattern_targets(engine: &mut Engine<'_>, node: &ruby_prism::Node<'_>) {
+fn collect_pattern_targets(node: &ruby_prism::Node<'_>) -> Vec<(Vec<u8>, usize)> {
     struct TargetCollector {
         targets: Vec<(Vec<u8>, usize)>,
     }
@@ -1372,7 +1374,11 @@ fn declare_and_assign_pattern_targets(engine: &mut Engine<'_>, node: &ruby_prism
         targets: Vec::new(),
     };
     collector.visit(node);
-    for (name, offset) in collector.targets {
+    collector.targets
+}
+
+fn declare_and_assign_pattern_targets(engine: &mut Engine<'_>, node: &ruby_prism::Node<'_>) {
+    for (name, offset) in collect_pattern_targets(node) {
         if !engine.table.variable_exists(&name) {
             engine.declare_variable(name.clone(), offset, DeclarationKind::PatternMatch);
         }
@@ -1382,6 +1388,14 @@ fn declare_and_assign_pattern_targets(engine: &mut Engine<'_>, node: &ruby_prism
         a.in_branch = engine.branch_depth > 0;
         a.branch_id = engine.current_branch_id();
         engine.table.assign_to_variable(&name, a);
+    }
+}
+
+fn declare_pattern_targets(engine: &mut Engine<'_>, node: &ruby_prism::Node<'_>) {
+    for (name, offset) in collect_pattern_targets(node) {
+        if !engine.table.variable_exists(&name) {
+            engine.declare_variable(name.clone(), offset, DeclarationKind::PatternMatch);
+        }
     }
 }
 

--- a/tests/fixtures/cops/rspec/leaky_local_variable/no_offense.rb
+++ b/tests/fixtures/cops/rspec/leaky_local_variable/no_offense.rb
@@ -613,4 +613,20 @@ describe SomeClass do
   end
 end
 
+# Rightward pattern-match assignment (`expr => pattern`) binds locals.
+# RuboCop's VariableForce declares these vars without creating assignments,
+# so LeakyLocalVariable has no assignment to flag.
+RSpec.describe NumberFormatHelper do
+  describe "#number_with_limit" do
+    [
+      { input: 10, opts: {}, result: "10" }
+    ].each do |test_case|
+      test_case => { input:, opts:, result: }
+
+      it "renders #{input} with #{opts} as #{result}" do
+        expect(number_with_limit(input, opts)).to eq(result)
+      end
+    end
+  end
+end
 


### PR DESCRIPTION
## Summary
- The VF engine's `visit_match_required_node` (added in 725a30c1e to support Lint/ShadowingOuterLocalVariable) both declared **and** assigned pattern-match targets. RuboCop's `process_pattern_match_variable` only declares, so cops that iterate `variable.assignments` (e.g. RSpec/LeakyLocalVariable) were wrongly seeing assignments for pattern-match-only bindings.
- Split the helper into `declare_pattern_targets` (declare-only, matches RuboCop) and the original `declare_and_assign_pattern_targets` (kept for `visit_in_node`). `MatchRequiredNode` now uses the declare-only variant.
- Fixes the FP on opf/openproject `spec/helpers/number_format_helper_spec.rb:65` (`test_case => { input:, opts:, result: }`).

## Test plan
- [x] New `no_offense.rb` fixture case for rightward pattern-match in a describe block passes
- [x] All LeakyLocalVariable fixture + unit tests pass
- [x] ShadowingOuterLocalVariable / UselessAssignment / VF-dependent cop tests pass (declaration is still performed, so shadowing detection is unaffected)
- [ ] CI corpus oracle reports 0 FP / 0 FN for RSpec/LeakyLocalVariable

🤖 Generated with [Claude Code](https://claude.com/claude-code)