### PR TITLE
Fix Lint/ShadowedArgument FN for def nested in begin/ensure

### DIFF
--- a/src/cop/lint/shadowed_argument.rs
+++ b/src/cop/lint/shadowed_argument.rs
@@ -65,6 +65,18 @@
 /// (no receiver, no arguments) in `RefCollector` as implicit references, gated
 /// by the `IgnoreImplicitReferences` config like `ForwardingSuperNode`.
 ///
+/// FN fix (1 corpus, 2026-04-17): a def (or block/lambda) nested inside an
+/// outer begin/ensure body inherited the outer branch context because
+/// `visit_def_node`/`visit_block_node`/`visit_lambda_node` saved and reset
+/// `branch_depth` but left `branch_stack` populated with the outer begin
+/// branch. When an `&&` short-circuit was pushed inside the def, the
+/// `current_shadowing_in_branch` scan walked the stack, found the outer
+/// non-short-circuit begin branch, and incorrectly marked the def's own
+/// shadowing assignment as conditional (seeing_is_believing compatibility.rb
+/// line 15 `char && block = lambda { |c| char }`). Fixed by also saving
+/// and clearing `branch_stack` on scope entry so inner scope branch checks
+/// only see branches pushed after scope entry.
+///
 /// FP fix (5 corpus, 2026-04-03): assignments in `case` predicates
 /// (e.g., `case value = super`) were treated as unconditional because the
 /// VariableForce engine visited the case predicate before incrementing

--- a/src/cop/variable_force/engine.rs
+++ b/src/cop/variable_force/engine.rs
@@ -837,6 +837,7 @@ impl<'pr> Visit<'pr> for Engine<'_> {
         };
         let loc = node.location();
         let saved_depth = self.branch_depth;
+        let saved_stack = std::mem::take(&mut self.branch_stack);
         self.branch_depth = 0;
         self.enter_scope(kind, loc.start_offset(), loc.end_offset());
         if let Some(params) = node.parameters() {
@@ -847,15 +848,19 @@ impl<'pr> Visit<'pr> for Engine<'_> {
         }
         self.leave_scope();
         self.branch_depth = saved_depth;
+        self.branch_stack = saved_stack;
     }
 
     fn visit_block_node(&mut self, node: &ruby_prism::BlockNode<'pr>) {
         let loc = node.location();
         let body_empty = node.body().is_none();
-        // Save and reset branch_depth: block body starts a fresh scope.
-        // Assignments to outer variables are marked captured_by_block by the
-        // variable table, which the cop uses as a conditional indicator.
+        // Save and reset branch_depth/branch_stack: block body starts a fresh
+        // scope. Assignments to outer variables are marked captured_by_block
+        // by the variable table, which the cop uses as a conditional indicator.
+        // Clearing branch_stack ensures outer branches (e.g. a begin/ensure
+        // body wrapping the block) do not bleed into in-block branch checks.
         let saved_depth = self.branch_depth;
+        let saved_stack = std::mem::take(&mut self.branch_stack);
         self.branch_depth = 0;
         self.enter_scope(ScopeKind::Block, loc.start_offset(), loc.end_offset());
         self.table.current_scope_mut().body_empty = body_empty;
@@ -869,12 +874,14 @@ impl<'pr> Visit<'pr> for Engine<'_> {
         }
         self.leave_scope();
         self.branch_depth = saved_depth;
+        self.branch_stack = saved_stack;
     }
 
     fn visit_lambda_node(&mut self, node: &ruby_prism::LambdaNode<'pr>) {
         let loc = node.location();
         let body_empty = node.body().is_none();
         let saved_depth = self.branch_depth;
+        let saved_stack = std::mem::take(&mut self.branch_stack);
         self.branch_depth = 0;
         self.enter_scope(ScopeKind::Block, loc.start_offset(), loc.end_offset());
         self.table.current_scope_mut().body_empty = body_empty;
@@ -888,6 +895,7 @@ impl<'pr> Visit<'pr> for Engine<'_> {
         }
         self.leave_scope();
         self.branch_depth = saved_depth;
+        self.branch_stack = saved_stack;
     }
 
     fn visit_class_node(&mut self, node: &ruby_prism::ClassNode<'pr>) {

--- a/tests/fixtures/cops/lint/shadowed_argument/offense.rb
+++ b/tests/fixtures/cops/lint/shadowed_argument/offense.rb
@@ -158,3 +158,15 @@ def initialize(x, y = nil, &action)
   set_position(x, y)
   action&.call
 end
+
+# FN fix: def nested inside `begin/ensure` must not treat the outer begin body
+# as a conditional branch for the def's own short-circuit shadowing.
+begin
+  def scrub(char = nil, &block)
+    char && block = lambda { |c| char }
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ShadowedArgument: Argument `block` was shadowed by a local variable before it was used.
+    block.call("x")
+  end
+ensure
+  nil
+end


### PR DESCRIPTION
## Summary
- Fix 1 corpus FN for `Lint/ShadowedArgument` default config (seeing_is_believing `compatibility.rb:15`).
- Root cause: `visit_def_node`/`visit_block_node`/`visit_lambda_node` saved/reset `branch_depth` on scope entry but left `branch_stack` populated with outer branches. An `&&` short-circuit inside the inner scope pushed its own branch, and `current_shadowing_in_branch` then found the outer begin/ensure body branch (non-short-circuit) on the stack and flagged the inner assignment as conditional — suppressing the offense.
- Fix: save and clear `branch_stack` alongside `branch_depth` on scope entry for def/block/lambda so inner branch checks only see branches pushed after scope entry.

## Test plan
- [x] New `offense.rb` fixture exercises `begin ... def ... char && block = ... ensure end`
- [x] All 96 VariableForce consumer tests pass (ShadowedArgument, UselessAssignment, UnusedMethodArgument, UnusedBlockArgument, ShadowingOuterLocalVariable, UnderscorePrefixedVariableName, InfiniteLoop, MapIntoArray, LeakyLocalVariable, SaveBang)
- [x] Full `cargo test --release` passes
- [ ] CI cop-check-gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)