### PR TITLE
Fix Rails/Delegate FP on modifier-if wrapping def

### DIFF
--- a/scripts/check_cop.py
+++ b/scripts/check_cop.py
@@ -1231,8 +1231,15 @@ def _run_rubocop_for_variant(
         repo_dir,
     ]
     try:
+        # Run from within the repo so RuboCop's make_excludes_absolute
+        # prefixes relative cop Exclude patterns (e.g., `**/*.gemspec`) with
+        # the repo path. Without cwd=repo_dir, RuboCop prefixes with the
+        # caller's cwd, the pattern no longer matches the target files, and
+        # patterns like Rails/TimeZone's `Exclude: ['**/*.gemspec']` silently
+        # stop excluding — producing spurious FNs vs the corpus oracle.
         result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout, env=env)
+            cmd, capture_output=True, text=True, timeout=timeout, env=env,
+            cwd=repo_dir)
         data = json.loads(result.stdout)
         # Filter to only the requested cop and deduplicate by (path, line),
         # matching the deduplication that run_nitrocop applies on the NC side.

--- a/src/cop/rails/delegate.rs
+++ b/src/cop/rails/delegate.rs
@@ -277,6 +277,19 @@ use ruby_prism::Visit;
 ///   wrappers such as `CONST = Class.new do`, `class_exec do`, and `if ... class`.
 ///   Visibility now uses Prism's full visitor and checks every statement list,
 ///   while keeping RuboCop's sibling-scope rules intact.
+///
+/// ## Investigation (2026-04-17): FP=1 on ruby/did_you_mean
+///
+/// `def distance(...) end if RUBY_ENGINE != 'jruby'` inside `module_eval do`
+/// with a sibling `module_function`. Prism's modifier-if parses the `def ... end`
+/// as an `IfNode` sharing its start offset with the inner `DefNode`. The sibling
+/// scan's `contains_def_at` only recognised the def itself and defs passed as
+/// access-modifier arguments, so it didn't spot the def inside the IfNode, and
+/// the visitor fell through to the if-body scope where `module_function` is not
+/// a sibling. RuboCop's `each_ancestor(:module, :begin)` treats conditional
+/// wrappers as transparent, so it finds `module_function` in the outer `:begin`.
+/// Fix: `contains_def_at` now recurses into `IfNode`/`UnlessNode` branches so
+/// the outer scope still recognises the wrapped def.
 pub struct Delegate;
 
 impl Cop for Delegate {
@@ -656,6 +669,42 @@ impl<'pr> VisibilityChecker<'_> {
                         && arg.location().start_offset() == self.def_offset
                     {
                         return true;
+                    }
+                }
+            }
+        }
+        // Conditional wrappers (`def ... end if cond`, `def ... end unless cond`,
+        // or prefix `if cond; def ...; end`) are transparent for visibility scope:
+        // RuboCop's `each_ancestor(:module, :begin)` walks past them, so a def
+        // inside an `if` still sees access modifiers from the outer scope.
+        if let Some(if_node) = node.as_if_node() {
+            if let Some(stmts) = if_node.statements() {
+                for s in stmts.body().iter() {
+                    if self.contains_def_at(&s) {
+                        return true;
+                    }
+                }
+            }
+            if let Some(subsequent) = if_node.subsequent() {
+                if self.contains_def_at(&subsequent) {
+                    return true;
+                }
+            }
+        }
+        if let Some(unless_node) = node.as_unless_node() {
+            if let Some(stmts) = unless_node.statements() {
+                for s in stmts.body().iter() {
+                    if self.contains_def_at(&s) {
+                        return true;
+                    }
+                }
+            }
+            if let Some(else_clause) = unless_node.else_clause() {
+                if let Some(stmts) = else_clause.statements() {
+                    for s in stmts.body().iter() {
+                        if self.contains_def_at(&s) {
+                            return true;
+                        }
                     }
                 }
             }

--- a/tests/fixtures/cops/rails/delegate/no_offense.rb
+++ b/tests/fixtures/cops/rails/delegate/no_offense.rb
@@ -347,3 +347,14 @@ q - Quit, do not update ignored warnings
     @ignore_config.unignore warning
   end
 end
+
+# `end if cond` modifier-if wrapping a def inside a block body where
+# `module_function` is a sibling. The IfNode shares its start offset with
+# the DefNode in Prism, so the visibility check must recurse through the
+# IfNode to see the `module_function` sibling.
+DidYouMean::JaroWinkler.module_eval do
+  module_function
+  def distance(str1, str2)
+    ::JaroWinkler.distance(str1, str2)
+  end if RUBY_ENGINE != 'jruby'
+end


### PR DESCRIPTION
## Summary

- Fixes the last outstanding Rails/Delegate FP in the corpus (`ruby/did_you_mean @ 74d3054: evaluation/calculator.rb:35`): a `def ... end if cond` inside `module_eval do` with a sibling `module_function`. Prism's modifier-if shares its start offset with the inner def, but the sibling-scope check's \`contains_def_at\` didn't recurse through the IfNode, so the outer block body's \`module_function\` was never consulted. RuboCop's \`each_ancestor(:module, :begin)\` treats conditional wrappers as transparent; matching that behaviour fixes the FP.
- Also carries a cherry-picked check_cop.py cwd fix from #2246 so the variant rubocop invocation prefixes relative Exclude patterns consistently with the corpus oracle.

## Test plan

- [ ] cop-check (all shards) green for Rails/Delegate
- [ ] Regression fixture added in `tests/fixtures/cops/rails/delegate/no_offense.rb` covering the modifier-if / sibling-module_function pattern
- [ ] Full cargo test suite passes (6105 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)