### PR TITLE
Fix Layout/SpaceInsideParens space variant

### DIFF
--- a/src/cop/layout/space_inside_parens.rs
+++ b/src/cop/layout/space_inside_parens.rs
@@ -142,6 +142,22 @@ use crate::parse::source::SourceFile;
 /// Fix: add `FindPatternNode` paren extraction, and skip close-side
 /// missing-space checks only when the final inner node is a multiline plain
 /// quoted `StringNode` whose closing quote is immediately before the outer `)`.
+///
+/// ## Corpus investigation (2026-04-19)
+///
+/// The `space` variant still showed ~100 FN from binstub-style sources like
+/// `abort("Your bin/bundle ...\nReplace ... again.")` — a plain double-quoted
+/// string with a real embedded newline inside `()`. The multiline-plain-string
+/// exemption above was too broad: it skipped close-side checks for every
+/// multiline `"..."` and `'...'`, but RuboCop only ignores the close side when
+/// Parser emits a single combined `tSTRING` token. Parser only does that for
+/// double-quoted strings where every newline is preceded by an odd number of
+/// backslashes (i.e. `\<newline>` line continuations). Any bare newline — or
+/// an escaped backslash followed by a newline — triggers separate
+/// `tSTRING_BEG`/`tSTRING_END` tokens, and the close side fires.
+///
+/// Fix: restrict the exemption to double-quoted strings whose interior
+/// contains only line-continuation newlines.
 pub struct SpaceInsideParens;
 
 const MSG: &str = "Space inside parentheses detected.";
@@ -744,7 +760,7 @@ fn check_missing_close_space(
     let Some(prev_code) = close_side else {
         return;
     };
-    if ignores_close_side_for_multiline_plain_string(node, prev_code) {
+    if ignores_close_side_for_multiline_plain_string(node, bytes, prev_code) {
         return;
     }
     if allow_consecutive_right_parens && bytes.get(prev_code) == Some(&b')') {
@@ -777,7 +793,7 @@ fn check_compact_close_space(
     let Some(prev_code) = close_side else {
         return;
     };
-    if ignores_close_side_for_multiline_plain_string(node, prev_code) {
+    if ignores_close_side_for_multiline_plain_string(node, bytes, prev_code) {
         return;
     }
 
@@ -828,6 +844,7 @@ fn compact_allows_consecutive_close_paren(
 
 fn ignores_close_side_for_multiline_plain_string(
     node: &ruby_prism::Node<'_>,
+    bytes: &[u8],
     prev_code: usize,
 ) -> bool {
     let Some(last_inner) = last_inner_node(node) else {
@@ -843,11 +860,46 @@ fn ignores_close_side_for_multiline_plain_string(
     let Some(closing) = string.closing_loc() else {
         return false;
     };
-    if !matches!(opening.as_slice(), b"\"" | b"'") || closing.as_slice() != opening.as_slice() {
+    // Only double-quoted strings can fold multiple source lines into a single
+    // `tSTRING` token via `\<newline>` continuations. Single-quoted strings
+    // always emit separate `tSTRING_BEG`/`tSTRING_END` tokens even with
+    // line continuations, so their close side is still checked by RuboCop.
+    if opening.as_slice() != b"\"" || closing.as_slice() != b"\"" {
+        return false;
+    }
+    if closing.start_offset() != prev_code {
         return false;
     }
 
-    string.location().as_slice().contains(&b'\n') && closing.start_offset() == prev_code
+    let content = &bytes[opening.end_offset()..closing.start_offset()];
+    if !content.contains(&b'\n') {
+        return false;
+    }
+
+    // RuboCop only sees a single combined `tSTRING` token when every newline
+    // in the string is preceded by an odd number of backslashes (i.e. is a
+    // line-continuation). A bare newline (even backslash count, including 0)
+    // causes Parser to emit `tSTRING_BEG` / `tSTRING_END` separately, and the
+    // close-side check fires on the `)` line.
+    only_line_continuation_newlines(content)
+}
+
+fn only_line_continuation_newlines(content: &[u8]) -> bool {
+    for (idx, &byte) in content.iter().enumerate() {
+        if byte != b'\n' {
+            continue;
+        }
+        let mut backslashes = 0usize;
+        let mut back = idx;
+        while back > 0 && content[back - 1] == b'\\' {
+            backslashes += 1;
+            back -= 1;
+        }
+        if backslashes % 2 == 0 {
+            return false;
+        }
+    }
+    true
 }
 
 fn last_inner_node<'a>(node: &ruby_prism::Node<'a>) -> Option<ruby_prism::Node<'a>> {
@@ -1036,6 +1088,30 @@ mod tests {
         assert_eq!(diags[0].location.line, 1);
         assert_eq!(diags[0].location.column, 7);
         assert!(diags[0].message.contains("No space"));
+    }
+
+    #[test]
+    fn space_style_flags_close_side_for_real_newline_string() {
+        use crate::testutil::run_cop_full_with_config;
+        use std::collections::HashMap;
+
+        let config = CopConfig {
+            options: HashMap::from([(
+                "EnforcedStyle".into(),
+                serde_yml::Value::String("space".into()),
+            )]),
+            ..CopConfig::default()
+        };
+        // Real newline inside a double-quoted string -> Parser emits separate
+        // tSTRING_BEG/tSTRING_END tokens, so RuboCop fires on both open and
+        // close sides.
+        let src = b"abort(\"line one\nline two\")\n";
+        let diags = run_cop_full_with_config(&SpaceInsideParens, src, config);
+        assert_eq!(
+            diags.len(),
+            2,
+            "should flag both open and close sides: {diags:?}"
+        );
     }
 
     #[test]

--- a/tests/fixtures/cops/layout/space_inside_parens/offense.space.rb
+++ b/tests/fixtures/cops/layout/space_inside_parens/offense.space.rb
@@ -5,3 +5,8 @@ in Point(*, 1, *a)
                  ^ Layout/SpaceInsideParens: No space inside parentheses detected.
   a
 end
+
+abort("hello
+      ^ Layout/SpaceInsideParens: No space inside parentheses detected.
+line two")
+         ^ Layout/SpaceInsideParens: No space inside parentheses detected.


### PR DESCRIPTION
## Summary
- Close-side FNs on `EnforcedStyle=space` from binstub-style sources like `abort("...\n...")` (plain double-quoted string with an embedded real newline inside parens).
- Parser gem only emits a single `tSTRING` token spanning multiple source lines when every newline inside the string is a `\<newline>` line continuation (odd backslash count). A bare newline (or `\\` followed by newline) produces separate `tSTRING_BEG`/`tSTRING_END` tokens, and RuboCop's close-side check fires on the `)` line.
- Previous heuristic skipped close-side for every multiline `"..."`/`'...'`, masking ~100 FN across the corpus. Restricted the exemption to double-quoted strings with line-continuation-only newlines.

## Test plan
- [ ] Existing variant fixtures still pass locally (`cargo test --lib -- cop::layout::space_inside_parens`).
- [ ] CI cop-check-gate passes (including `--check-variants`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)