### PR TITLE
Fix variant check gate false regressions on uncovered repos

### DIFF
--- a/scripts/check_cop.py
+++ b/scripts/check_cop.py
@@ -364,15 +364,24 @@ show up in the cop-specific sample. They're selected by highest nitrocop_total
 
 
 def variant_covered_repos(run_id: int | None) -> set[str] | None:
-    """Return the set of repos that the variant oracle actually ran against.
+    """Return the set of repos that the variant oracle actually tested.
 
     The variant oracle uses --max-variant-repos to cap variant runs to the
-    top-N repos by manifest order. Repos beyond that limit have no variant
-    baseline data — any nitrocop output on them during --style CI runs
-    becomes a false "regression" against a stale 0-offense baseline.
+    first N repos in manifest order (sorted by stars). Repos beyond that
+    limit have no variant baseline data — any nitrocop/rubocop divergence
+    on them during --style CI runs becomes a false "regression" against a
+    zero baseline.
 
-    Returns None when the oracle artifact doesn't expose per-repo variant
-    data (older artifacts); callers should then skip filtering.
+    Reconstructs the tested set from manifest order + the oracle batch's
+    ``total_repos`` field rather than scanning ``by_repo_cop``, because
+    ``by_repo_cop`` only contains repos with cop-level divergence — repos
+    that the oracle tested AND matched perfectly never appear in it and
+    must still be recognized as "tested" so going from 0 to N divergence
+    gets flagged.
+
+    Returns None when run_id is missing, the artifact can't be read, the
+    artifact predates the ``total_repos`` field, or the manifest is
+    missing; callers should then skip filtering.
     """
     if run_id is None:
         return None
@@ -384,11 +393,15 @@ def variant_covered_repos(run_id: int | None) -> set[str] | None:
         data = json.loads(path.read_text())
     except (json.JSONDecodeError, OSError):
         return None
-    covered: set[str] = set()
-    for batch in data.get("batches", []):
-        for repo_id in batch.get("by_repo_cop", {}):
-            covered.add(repo_id)
-    return covered or None
+    limits = [batch.get("total_repos", 0) for batch in data.get("batches", [])]
+    limit = max(limits) if limits else 0
+    if limit <= 0:
+        return None
+    manifest = load_manifest()
+    if not manifest:
+        return None
+    # `manifest` preserves manifest.jsonl insertion order (Python 3.7+ dicts).
+    return set(list(manifest.keys())[:limit])
 
 
 def canary_repos(
@@ -454,6 +467,14 @@ def relevant_repos_for_cop(
         if cop_name in cops:
             relevant.add(repo_id)
 
+    # Variant checks only have baseline data for the first N manifest repos
+    # (the oracle's --max-variant-repos limit). Sampling any repo beyond that
+    # limit produces a false regression because the baseline entry is missing
+    # (treated as 0) while the actual nc/rc divergence is non-zero. Filter
+    # `relevant` down to tested repos when running a variant check.
+    if variant_covered_repos is not None:
+        relevant &= variant_covered_repos
+
     # For Include-gated cops with zero baseline, sample from the full manifest.
     # These cops have no oracle data because both tools fail to resolve their
     # Include patterns. We sample broadly to get coverage.
@@ -470,6 +491,10 @@ def relevant_repos_for_cop(
             relevant = set(manifest.keys())
             print(f"  Include-gated cop with zero baseline — sampling from "
                   f"{len(relevant)} manifest repos", file=sys.stderr)
+        # Re-apply the variant filter after the Include-gated fallback so
+        # broad manifest sampling can't smuggle in untested repos.
+        if variant_covered_repos is not None:
+            relevant &= variant_covered_repos
 
     if sample is not None and len(relevant) > sample:
         # Always include repos with known divergence (FP or FN)
@@ -805,6 +830,7 @@ def rerun_local_per_repo(
     total_shards: int | None = None,
     sample: int | None = None,
     include_gated: bool = False,
+    variant_covered_repos: set[str] | None = None,
 ) -> dict[str, int]:
     """Re-run nitrocop locally using per-repo subprocess mode.
 
@@ -817,8 +843,11 @@ def rerun_local_per_repo(
 
     relevant_repos = None
     if quick:
-        relevant_repos = relevant_repos_for_cop(cop_name, data, sample=sample,
-                                                include_gated=include_gated)
+        relevant_repos = relevant_repos_for_cop(
+            cop_name, data, sample=sample,
+            include_gated=include_gated,
+            variant_covered_repos=variant_covered_repos,
+        )
         if not has_activity_index:
             print(
                 "WARNING: corpus artifact lacks cop_activity_repos; "
@@ -1414,14 +1443,24 @@ def main():
 
     ensure_binary()
 
+    # Variant checks must only sample from repos the oracle actually tested
+    # (the first --max-variant-repos entries by manifest order). Sampling any
+    # repo beyond that yields a false regression because the baseline is zero
+    # but the nc/rc divergence is real. Compute once here and thread through
+    # both the clone path and the local-rerun path.
+    _style_label = None
+    if args.style and "=" in args.style:
+        _style_label = args.style.split("=", 1)[1]
+    _variant_covered = (
+        variant_covered_repos(corpus_run_id)
+        if (_style_label or args.check_variants)
+        else None
+    )
+
     # Validate local corpus matches manifest (warns about stale/missing repos)
     if args.rerun:
         if args.clone:
             # Clone into temp dir with oracle-identical path structure
-            # Extract style label from --style for variant-aware sampling
-            _style_label = None
-            if args.style and "=" in args.style:
-                _style_label = args.style.split("=", 1)[1]
             tmpdir = clone_repos_for_cop(
                 args.cop, data,
                 shard_index=args.shard_index, total_shards=args.total_shards,
@@ -1521,6 +1560,7 @@ def main():
                 total_shards=args.total_shards,
                 sample=args.sample,
                 include_gated=include_gated and zero_baseline,
+                variant_covered_repos=_variant_covered,
             )
             save_cached_results(args.cop, per_repo)
 

--- a/tests/python/test_check_cop.py
+++ b/tests/python/test_check_cop.py
@@ -142,37 +142,89 @@ def test_relevant_repos_with_variant_covered_filter():
     assert "canary-uncovered" not in result
 
 
+def test_relevant_repos_filters_main_activity_set_by_variant_coverage():
+    """Variant check must not sample cop-active repos outside oracle coverage.
+
+    Before the fix the filter only touched canaries; high-activity repos
+    beyond --max-variant-repos still went into the main sample, which made
+    --style CI runs compare a real nc/rc divergence against a zero baseline
+    and flag it as a regression even though the oracle never tested that
+    repo for variants.
+    """
+    data = {
+        "cop_activity_repos": {
+            "Style/Foo": ["covered-active", "uncovered-active"],
+        },
+        "by_repo_cop": {
+            "uncovered-diverging": {
+                "Style/Foo": {"matches": 0, "fp": 1, "fn": 0},
+            },
+        },
+        "by_repo": [],
+    }
+    result = check_cop.relevant_repos_for_cop(
+        "Style/Foo", data,
+        variant_covered_repos={"covered-active"},
+    )
+    assert result == {"covered-active"}
+
+
+def test_relevant_repos_empty_without_variant_filter_still_skips_for_no_coverage():
+    """An empty activity set with variant filter shouldn't fall back to all repos."""
+    data = {
+        "cop_activity_repos": {"Style/Foo": ["uncovered"]},
+        "by_repo_cop": {},
+        "by_repo": [],
+    }
+    result = check_cop.relevant_repos_for_cop(
+        "Style/Foo", data,
+        variant_covered_repos={"some-other-repo"},
+    )
+    assert result == set()
+
+
 def test_variant_covered_repos_returns_none_for_no_run_id():
     assert check_cop.variant_covered_repos(None) is None
 
 
-def test_variant_covered_repos_parses_variant_baselines(tmp_path, monkeypatch):
-    """Loads variant-covered repo IDs from the oracle artifact."""
+def test_variant_covered_repos_uses_manifest_prefix(tmp_path, monkeypatch):
+    """Returns the first N manifest repos based on the oracle's total_repos.
+
+    The oracle runs variants on the first --max-variant-repos entries in
+    manifest order, so the covered set is that prefix — not just the repos
+    that diverged. Perfect-match repos inside the prefix must be covered so
+    that new regressions on them are still caught.
+    """
     variant_path = tmp_path / "style-variant-results-42.json"
     variant_path.write_text(json.dumps({
         "batches": [
-            {"name": "variant_batch_1", "by_repo_cop": {
-                "repo-in-batch1": {"Style/Foo": {"fp": 1, "fn": 0}},
-                "repo-in-both": {"Style/Foo": {"fp": 0, "fn": 1}},
+            {"name": "variant_batch_1", "total_repos": 2, "by_repo_cop": {
+                "diverging-only": {"Style/Foo": {"fp": 1, "fn": 0}},
             }},
-            {"name": "variant_batch_2", "by_repo_cop": {
-                "repo-in-batch2": {"Style/Bar": {"fp": 0, "fn": 1}},
-                "repo-in-both": {"Style/Foo": {"fp": 0, "fn": 1}},
-            }},
+            {"name": "variant_batch_2", "total_repos": 3, "by_repo_cop": {}},
         ],
     }))
+    manifest_path = tmp_path / "manifest.jsonl"
+    manifest_path.write_text("\n".join(
+        json.dumps({"id": repo_id, "repo_url": "u", "sha": "s"})
+        for repo_id in ("first-covered", "second-covered", "third-covered",
+                        "fourth-beyond-limit")
+    ) + "\n")
 
     def fake_path(run_id):
         return variant_path if run_id == 42 else None
 
-    # Patch the module-level resolver used inside variant_covered_repos
+    # Patch the module-level resolver and the manifest path.
     import sys as _sys
     fake_mod = type(_sys)("shared.corpus_artifacts")
     fake_mod.get_variant_results_path = fake_path
     monkeypatch.setitem(_sys.modules, "shared.corpus_artifacts", fake_mod)
+    monkeypatch.setattr(check_cop, "MANIFEST_PATH", manifest_path)
 
     covered = check_cop.variant_covered_repos(42)
-    assert covered == {"repo-in-batch1", "repo-in-batch2", "repo-in-both"}
+    # Largest total_repos across batches is 3 → first three manifest repos.
+    # Includes perfect-match repos the oracle tested, not just by_repo_cop.
+    assert covered == {"first-covered", "second-covered", "third-covered"}
 
 
 def test_relevant_repos_with_sample_includes_canaries():


### PR DESCRIPTION
## Summary

- CI's variant gate (`check_cop.py --check-variants`) was producing massive false-positive regressions (e.g., +1575 FN on #2290) because `relevant_repos_for_cop` sampled repos the variant oracle never tested.
- The variant oracle uses `--max-variant-repos 1000`, so repos beyond manifest position 1000 have no baseline. read-ruby (pos 3804), noosfero (pos 4402), etc. were getting pulled in via the default-config `cop_activity_repos` list, their real `nc - rc` divergence counted against a 0 baseline, and flagged as regressions.

## What changed

1. **`variant_covered_repos()`** now reconstructs the tested set from `batch.total_repos` + manifest order, not from `by_repo_cop`. Perfect-match repos inside the tested prefix are now recognized as "tested" so a 0→N regression still gets flagged.
2. **`relevant_repos_for_cop`** intersects `relevant` with the covered set on both the main and Include-gated paths when a variant filter is supplied.
3. **`rerun_local_per_repo`** threads the filter through so local `--style` runs match CI behavior.

## Test plan
- [x] `uv run pytest tests/python/test_check_cop.py` (77 passed)
- [x] Added 3 new tests covering the main-set filter, empty-after-filter, and the manifest-prefix semantics
- [ ] CI cop-check-gate passes (validates the fix end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)