### PR TITLE
Fix variant oracle: preserve cop_activity_repos + resolve symlink paths

### DIFF
--- a/.github/workflows/corpus-oracle.yml
+++ b/.github/workflows/corpus-oracle.yml
@@ -444,6 +444,28 @@ jobs:
               --repo-sha "$REPO_SHA" \
               --timeout 900 || true
 
+            # Resolve symlink paths + deduplicate offenses in each variant
+            # batch's JSON, same as the default pipeline does at line 339.
+            # Without this, repos with internal symlinks (e.g. rabl's fixture
+            # directories that symlink posts_controller_test.rb across
+            # padrino/rails2/rails3 fixtures) count the same file multiple
+            # times, inflating variant counts relative to what check_cop.py's
+            # _run_rubocop_for_variant produces (which normalizes via
+            # os.path.realpath). The mismatch surfaces as a false "regression"
+            # in the variant gate.
+            #
+            # Must run before the repo dir is deleted — resolve_symlink_paths
+            # uses os.path.realpath which needs the files to exist.
+            for VC_BATCH_DIR in results/variant-nitrocop-variant_batch_*; do
+              [ -d "$VC_BATCH_DIR" ] || continue
+              VC_BATCH_NAME=$(basename "$VC_BATCH_DIR" | sed 's/variant-nitrocop-//')
+              VC_RC_JSON="results/variant-rubocop-${VC_BATCH_NAME}/${REPO_ID}.json"
+              VC_NC_JSON="${VC_BATCH_DIR}/${REPO_ID}.json"
+              python3 bench/corpus/resolve_symlink_paths.py \
+                "$VC_NC_JSON" "$VC_RC_JSON" \
+                2>/dev/null || true
+            done
+
             # Extract source context for variant offenses (same as default
             # pipeline). This enables variant examples to include source
             # snippets for fixture prepopulation and agent investigation.

--- a/bench/corpus/run_variant_batches.py
+++ b/bench/corpus/run_variant_batches.py
@@ -319,6 +319,21 @@ def merge_variant_results(
                 entry["by_repo_cop"] = filtered_repo_cop
             else:
                 entry["by_repo_cop"] = data["by_repo_cop"]
+        # Preserve per-cop repo activity so check_cop.py can recognize
+        # perfect-match repos (oracle exercised the cop but nitrocop matched
+        # rubocop exactly, so they're not in by_repo_cop). Without this,
+        # those repos look "untested" to the gate and any post-oracle count
+        # shift becomes a false regression.
+        if "cop_activity_repos" in data:
+            batch_cops = style_map.get(batch_name, {})
+            activity = data["cop_activity_repos"]
+            if batch_cops:
+                entry["cop_activity_repos"] = {
+                    cop: repos for cop, repos in activity.items()
+                    if cop in batch_cops
+                }
+            else:
+                entry["cop_activity_repos"] = activity
         merged["batches"].append(entry)
     return merged
 

--- a/scripts/check_cop.py
+++ b/scripts/check_cop.py
@@ -1036,10 +1036,15 @@ def load_variant_baselines(
 ) -> dict[str, dict]:
     """Load per-style baseline FP/FN from the oracle's style-variant-results.json.
 
-    Returns {style_label: {fp, fn, matches, by_repo: {repo_id: {fp, fn}}}}
-    or empty dict if unavailable.  ``by_repo`` is populated when the oracle
-    artifact contains per-repo divergence data (``by_repo_cop``); older
-    artifacts without this field will have an empty ``by_repo`` dict.
+    Returns {style_label: {fp, fn, matches, by_repo, activity_repos}} or empty
+    dict if unavailable.
+
+    ``by_repo`` maps repo_id -> {fp, fn} for repos with recorded divergence.
+
+    ``activity_repos`` is the set of repos the oracle exercised for this cop
+    but where nitrocop matched rubocop exactly (no divergence). These are
+    critical for the gate: without them, perfect-match repos look "untested"
+    and any post-oracle count shift becomes a false regression.
     """
     if run_id is None:
         return {}
@@ -1065,11 +1070,15 @@ def load_variant_baselines(
                             "fp": stats.get("fp", 0),
                             "fn": stats.get("fn", 0),
                         }
+                activity_repos = set(
+                    batch.get("cop_activity_repos", {}).get(cop_name, [])
+                )
                 baselines[label] = {
                     "fp": cop_entry.get("fp", 0),
                     "fn": cop_entry.get("fn", 0),
                     "matches": cop_entry.get("matches", 0),
                     "by_repo": by_repo,
+                    "activity_repos": activity_repos,
                 }
     return baselines
 

--- a/tests/python/test_run_variant_batches.py
+++ b/tests/python/test_run_variant_batches.py
@@ -167,6 +167,56 @@ def test_merge_variant_results_without_batches_dir(tmp_path):
     assert "style_label" not in batch["by_cop"][0]
 
 
+def test_merge_variant_results_preserves_cop_activity_repos(tmp_path):
+    """cop_activity_repos must carry through so check_cop.py can use it
+    as the "perfect match" baseline for repos the oracle exercised but
+    didn't record divergence for. Without this, those repos look untested
+    and any count shift becomes a false regression."""
+    batches_dir = tmp_path / "batches"
+    batches_dir.mkdir()
+    (batches_dir / "variant_batch_1.yml").write_text(
+        "inherit_from: ../baseline.yml\n"
+        "Style/Foo:\n"
+        "  EnforcedStyle: bar\n"
+    )
+
+    f1 = tmp_path / "style-variant-variant_batch_1.json"
+    f1.write_text(json.dumps({
+        "summary": {"total_repos": 10},
+        "by_cop": [
+            {"cop": "Style/Foo", "matches": 50, "fp": 2, "fn": 1},
+            {"cop": "Style/Other", "matches": 100, "fp": 0, "fn": 0},
+        ],
+        "cop_activity_repos": {
+            "Style/Foo": ["repo_a__abc", "repo_b__def", "repo_c__ghi"],
+            "Style/Other": ["repo_a__abc", "repo_b__def"],
+        },
+    }))
+
+    result = run_variant_batches.merge_variant_results([f1], batches_dir=batches_dir)
+    batch = result["batches"][0]
+    # Only Style/Foo kept (has override); Style/Other filtered out
+    assert batch["cop_activity_repos"] == {
+        "Style/Foo": ["repo_a__abc", "repo_b__def", "repo_c__ghi"],
+    }
+
+
+def test_merge_variant_results_cop_activity_without_batches_dir(tmp_path):
+    """Without batches_dir, cop_activity_repos pass through unfiltered."""
+    f1 = tmp_path / "style-variant-variant_batch_1.json"
+    f1.write_text(json.dumps({
+        "cop_activity_repos": {
+            "Style/Foo": ["repo_a"],
+            "Style/Other": ["repo_b"],
+        },
+    }))
+    result = run_variant_batches.merge_variant_results([f1])
+    assert result["batches"][0]["cop_activity_repos"] == {
+        "Style/Foo": ["repo_a"],
+        "Style/Other": ["repo_b"],
+    }
+
+
 def test_run_variant_batches_passes_only_flag(tmp_path):
     """Variant runs pass --only with only the cops overridden in that batch."""
     batches_dir = tmp_path / "batches"


### PR DESCRIPTION
## Summary

Two related bugs in the variant oracle pipeline that together produce false "regression" signals in the cop-check-gate for PRs that touch any variant cop.

### Bug A: `cop_activity_repos` dropped in variant artifact

`merge_variant_results` copies `by_repo_cop` into each batch entry but never propagates `cop_activity_repos`. That field distinguishes "oracle exercised this cop on this repo (NC==RC, no divergence)" from "oracle never touched this cop here" — without it, every perfect-match repo looks untested.

Fix: pass the field through, surface as `activity_repos: set[repo_id]` per style in `load_variant_baselines`.

### Bug B: variant pipeline skips symlink path resolution

The default corpus pipeline runs `resolve_symlink_paths.py` after each repo to canonicalize paths and dedup offenses that appear at a symlink + its realpath. The variant pipeline was skipping this step entirely.

For repos with internal symlinks (e.g. **nesquena/rabl**, which symlinks `posts_controller_test.rb` across seven fixture directories for padrino/rails2/rails3/rails3_2/rails4/rails5/rails6), the variant oracle recorded inflated counts: rabl's space-variant `Layout/SpaceInsideParens` was stored as **2804** in the artifact but `check_cop.py`'s `_run_rubocop_for_variant` normalizes via `os.path.realpath` and gets **2025**.

The gap (779 offenses) surfaced as the false `+779 FN` regression observed on PR #2301 — gate comparing normalized live counts to un-normalized oracle counts.

Fix: run `resolve_symlink_paths.py` on each variant batch's NC+RC JSON in `corpus-oracle.yml`, same as the default pipeline does. Verified locally: applying the script to the oracle artifact collapses rabl's count from 2804 to 2025, matching `_run_rubocop_for_variant` exactly.

## Verification

Triggered a filtered `Corpus Oracle` dispatch on rabl only (run `24641613277`) to confirm the pre-fix behavior, then re-triggered on this branch (run `24641920462`) to verify the fix in CI. Expect the new artifact to record 2025 instead of 2804 for rabl's space-variant SpaceInsideParens.

## Changes

- `bench/corpus/run_variant_batches.py` — `merge_variant_results` preserves `cop_activity_repos`, filtered by batch cops when batches_dir is provided
- `scripts/check_cop.py` — `load_variant_baselines` surfaces `activity_repos`
- `.github/workflows/corpus-oracle.yml` — apply `resolve_symlink_paths.py` to variant JSON before repo deletion
- `tests/python/test_run_variant_batches.py` — 2 new tests for the `cop_activity_repos` propagation

## Test plan
- [x] `uv run pytest tests/python/test_run_variant_batches.py tests/python/test_check_cop.py` (94 passed)
- [x] `uv run ruff check` clean
- [x] Manual verification: applying `resolve_symlink_paths.py` to CI's rabl artifact locally drops the count from 2804 to 2025, matching `_run_rubocop_for_variant`
- [ ] Re-triggered oracle (run 24641920462) confirms fixed count in CI artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)