### PR TITLE
Route variant gate's live rubocop through resolve_symlink_paths

### DIFF
--- a/scripts/check_cop.py
+++ b/scripts/check_cop.py
@@ -1279,11 +1279,31 @@ def _run_rubocop_for_variant(
             cmd, capture_output=True, text=True, timeout=timeout, env=env,
             cwd=repo_dir)
         data = json.loads(result.stdout)
+        # Apply the same in-place symlink normalization that the corpus oracle
+        # runs via bench/corpus/resolve_symlink_paths.py — write the JSON to a
+        # temp file, normalize, and read back. Using the exact same function
+        # keeps gate counts in parity with oracle counts on repos with
+        # internal symlinks (e.g., rabl's fixture directories). An inline
+        # os.path.realpath was not equivalent: if rubocop emits paths that
+        # don't resolve from the caller's cwd, realpath returns the unresolved
+        # path and symlink duplicates stay counted separately.
+        import tempfile
+        sys.path.insert(0, str(PROJECT_ROOT / "bench" / "corpus"))
+        from resolve_symlink_paths import resolve_rubocop_json
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tf:
+            json.dump(data, tf)
+            tmp_path = tf.name
+        try:
+            resolve_rubocop_json(tmp_path)
+            with open(tmp_path) as tf:
+                data = json.load(tf)
+        finally:
+            os.unlink(tmp_path)
         # Filter to only the requested cop and deduplicate by (path, line),
         # matching the deduplication that run_nitrocop applies on the NC side.
         seen: set[tuple[str, int]] = set()
         for f in data.get("files", []):
-            fpath = os.path.realpath(f.get("path", ""))
+            fpath = f.get("path", "")
             for o in f.get("offenses", []):
                 if o.get("cop_name") == cop:
                     seen.add((fpath, o["location"]["line"]))


### PR DESCRIPTION
## Summary

Follow-up to #2302. `_run_rubocop_for_variant` in `check_cop.py` was using an inline `os.path.realpath` to dedup offenses across symlinked paths — but that diverged from the oracle's `resolve_symlink_paths.py` logic on CI. Rabl's space-variant SpaceInsideParens showed:

- **Oracle (post-#2302)**: NC=2025, RC=2025, FN=0 ✅
- **Gate (pre this PR)**: NC=2025, RC=2804, FN=779 ❌

Same commit, same rubocop, same clone. The gap is that `resolve_symlink_paths.py` gates realpath on `os.path.exists(path)` and merges file entries by resolved path, while the inline code called `realpath` unconditionally. If rubocop emits a path that doesn't resolve from the Python caller's cwd (relative path + cwd mismatch), inline realpath returns the input unchanged and symlink duplicates stay counted separately.

Fix: route the variant gate's live rubocop output through the same `resolve_rubocop_json` function the oracle uses. Locally still returns 2025 on rabl; should clear the false +779 FN signal on PR #2301 in CI.

## Verification
- [x] Local `_run_rubocop_for_variant('/tmp/local_check/rabl', ...)` returns 2025 (unchanged)
- [x] `uv run pytest tests/python/test_check_cop.py` — 77 passed
- [x] `uv run ruff check` clean
- [ ] CI cop-check-gate passes on PR #2301 once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)