### PR TITLE
Exclude jruby's crashing encoding tests from corpus

### DIFF
--- a/bench/corpus/repo_excludes.json
+++ b/bench/corpus/repo_excludes.json
@@ -1,13 +1,15 @@
 {
   "_comment": "Per-repo file exclusions for the corpus oracle. Files listed here are excluded from RuboCop inspection via AllCops/Exclude overlay. With rescue_parser_crashes.rb loaded, crashes no longer kill subsequent files, but these exclusions still prevent known-crashy files from producing misleading 0-offense entries. Paths are relative to the repo root (glob syntax, same as AllCops/Exclude). Note: vendor/**/* is excluded globally in gen_repo_config.py.",
   "jruby__jruby__0303464": {
-    "comment": "RuboCop crashes during Lint/LiteralAsCondition on bench_compilation.rb and spec/ruby/language/if_spec.rb; Prism::Translation::Parser crashes on invalid multibyte regex escapes in test files, killing ~1000 files as collateral; test_logger.rb has same /[\\x0-\\xff]/ escape — RuboCop parser bails on line 16, so all cops report 0 offenses while Prism parses it fine",
+    "comment": "RuboCop crashes during Lint/LiteralAsCondition on bench_compilation.rb and spec/ruby/language/if_spec.rb; Prism::Translation::Parser crashes on invalid multibyte regex escapes in test files, killing ~1000 files as collateral; test_logger.rb has same /[\\x0-\\xff]/ escape — RuboCop parser bails on line 16, so all cops report 0 offenses while Prism parses it fine; test_euc_jp.rb (`invalid multibyte escape: /\\xA2\\xA2/`) and test_windows_1252.rb (`too short escaped multibyte character`) trip the same parser crash (surfaced as phantom FPs on SpaceInsideParens). Verified: those are the only two files in test/mri/ruby/enc/ that crash; the other 19 encoding tests parse cleanly.",
     "exclude": [
       "bench/compiler/bench_compilation.rb",
       "spec/ruby/language/if_spec.rb",
       "test/jruby/test_regexp.rb",
       "test/mri/logger/test_logger.rb",
-      "test/mri/ruby/test_regexp.rb"
+      "test/mri/ruby/test_regexp.rb",
+      "test/mri/ruby/enc/test_euc_jp.rb",
+      "test/mri/ruby/enc/test_windows_1252.rb"
     ]
   },
   "ruby__logger__00796ec": {


### PR DESCRIPTION
## Summary

Two files in jruby's MRI encoding test suite crash the RuboCop Parser gem:

- `test/mri/ruby/enc/test_euc_jp.rb` — `invalid multibyte escape: /\xA2\xA2/`
- `test/mri/ruby/enc/test_windows_1252.rb` — `too short escaped multibyte character`

Both use encoding-specific regex literals that only parse under their declared file encoding. RuboCop bails before any cop runs and emits 0 offenses; Prism (nitrocop) parses them fine. Every cop that matches these files produces phantom FPs.

This surfaced as the remaining +33 FP on jruby's shard for Layout/SpaceInsideParens on PR #2301's variant gate.

## Verification

Manually ran rubocop with `bundle exec rubocop --only Layout/SpaceInsideParens --config variant_batch_1.yml --format json` against every file in `test/mri/ruby/enc/` from the pinned SHA. Only these two produce non-JSON / fatal output; the other 19 parse cleanly. So the exclusion is limited to the specific files rather than the whole directory.

## Test plan
- [x] `python3 -m json.tool bench/corpus/repo_excludes.json` — valid JSON
- [ ] PR #2301 CI's variant gate drops to 0 FP on jruby after corpus oracle refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)