### PR TITLE
Fix Layout/FirstArgumentIndentation underflow on splat at offset 1

### DIFF
--- a/src/cop/layout/first_argument_indentation.rs
+++ b/src/cop/layout/first_argument_indentation.rs
@@ -503,7 +503,7 @@ fn base_range_start_offset(
         && call_start_offset >= 2
         && bytes.get(call_start_offset - 2) == Some(&b'*')
         && bytes.get(call_start_offset - 1) == Some(&b'*')
-        && is_splat_boundary(bytes.get(call_start_offset - 3).copied())
+        && is_splat_boundary(byte_before(bytes, call_start_offset, 3))
     {
         return call_start_offset - 2;
     }
@@ -511,7 +511,7 @@ fn base_range_start_offset(
     if !has_same_start_parent_call
         && call_start_offset >= 1
         && bytes.get(call_start_offset - 1) == Some(&b'*')
-        && is_splat_boundary(bytes.get(call_start_offset - 2).copied())
+        && is_splat_boundary(byte_before(bytes, call_start_offset, 2))
     {
         return call_start_offset - 1;
     }
@@ -524,6 +524,10 @@ fn is_splat_boundary(byte: Option<u8>) -> bool {
         byte,
         None | Some(b' ' | b'\t' | b'\n' | b'\r' | b'(' | b'[' | b'{' | b',')
     )
+}
+
+fn byte_before(bytes: &[u8], offset: usize, back: usize) -> Option<u8> {
+    offset.checked_sub(back).and_then(|i| bytes.get(i).copied())
 }
 
 fn is_bare_operator(name: &str, has_regular_dot: bool) -> bool {
@@ -684,6 +688,16 @@ mod tests {
         let source = b"foo(1, 2, 3)\n";
         let diags = run_cop_full(&FirstArgumentIndentation, source);
         assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn splat_call_at_offset_one_does_not_underflow() {
+        // Regression for fuzz crash c91fe5dc62ec40d2afa32f3fe5d1fb0cd957de10:
+        // a splat call whose callee starts at byte offset 1 used to read
+        // bytes[offset - 2] unconditionally and panic with "attempt to subtract
+        // with overflow" under cargo-fuzz's overflow-checks build.
+        let source = b"*o(\n@";
+        let _ = run_cop_full(&FirstArgumentIndentation, source);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the live fuzz crash that has been failing every nightly since 2026-04-16 (originally discovered in [run 24437839198](https://github.com/6/nitrocop/actions/runs/24437839198) on 2026-04-15, seed [`crash-c91fe5dc...`](https://github.com/6/nitrocop/blob/main/fuzz/seeds/fuzz_all_cops/crash-c91fe5dc62ec40d2afa32f3fe5d1fb0cd957de10) added by #2135 with no follow-up fix).

### Panic

```
thread '<unnamed>' panicked at src/cop/layout/first_argument_indentation.rs:514:40:
attempt to subtract with overflow
```

### Root cause

`base_range_start_offset` looks back two or three bytes from the call start to detect `*` / `**` splat receivers. The branches were guarded with `call_start_offset >= 1` (or `>= 2`) but then unconditionally indexed `bytes.get(call_start_offset - 2)` (or `- 3`). For input `*o(\n@`, the splatted call `o(` starts at byte offset 1, so `1 - 2` underflows `usize` and panics under cargo-fuzz's `overflow-checks=on` build.

### Fix

Route the lookback through a `byte_before` helper that uses `checked_sub` and returns `None` when the lookback walks past byte 0. `is_splat_boundary` already treats `None` as a boundary, so a splat call sitting at the very start of the file is correctly recognised as such — same end-result, no underflow.

Adds a unit test that runs the cop on the original 5-byte fuzz input and asserts no panic. Test runs in debug mode where `overflow-checks` is on by default, so the assertion would have caught the original bug.

## Test plan

- [x] `cargo test --lib -- cop::layout::first_argument_indentation` — 18/18 pass, including new `splat_call_at_offset_one_does_not_underflow`
- [x] `cargo fmt` and `cargo clippy --release -- -D warnings` clean
- [x] `cargo test --release` — full suite green (6157 lib tests pass)
- [x] Reverting the fix re-triggers the panic in the new unit test, confirming coverage
- [ ] Next nightly fuzz run executes the seed without exiting 77

🤖 Generated with [Claude Code](https://claude.com/claude-code)