### PR TITLE
Fix ResponseParsedBody cop to reject chained response calls

### DIFF
--- a/src/cop/rails/response_parsed_body.rs
+++ b/src/cop/rails/response_parsed_body.rs
@@ -6,20 +6,24 @@ use crate::parse::source::SourceFile;
 
 /// Rails/ResponseParsedBody
 ///
-/// FP fix: rubocop-rails 2.34 backs `minimum_target_rails_version 5.0` with
-/// `requires_gem 'railties', '>= 5.0'`, so this cop must stay disabled for
-/// legacy Rails 3.x/4.x repos and repos without `railties` in `Gemfile.lock`
-/// even when external configs force `TargetRailsVersion: 7.0`. Verified
-/// against RuboCop with a throwaway `railties 7.0` lockfile: the same
-/// `JSON.parse(response.body)` inside an RSpec `it do ... end` block is still
-/// an offense there, so the FP bucket was a version-gate mismatch, not a
-/// block-context exception.
+/// Matches `JSON.parse(response.body)` and, on Rails >= 7.1,
+/// `Nokogiri::HTML{,5}.parse(response.body)`.
 ///
-/// Corpus note: this cop is Include-gated (`spec/controllers/**/*.rb`,
-/// `spec/requests/**/*.rb`, etc.). These patterns come from the
-/// rubocop-rails gem config and resolve relative to base_dir (CWD for
-/// non-dotfile configs). Corpus runs must use `--repo-cwd` so that CWD
-/// equals the repo root and the Include patterns match.
+/// FP fix: RuboCop's node pattern requires the intermediate `response`
+/// call to have a nil receiver:
+///   (send (const {nil? cbase} :JSON) :parse (send (send nil? :response) :body))
+/// nitrocop previously matched any `*.response.body` chain, falsely flagging
+/// cases like `JSON.parse(error.response.body)` in request specs.
+///
+/// Version gating: rubocop-rails 2.34 backs `minimum_target_rails_version 5.0`
+/// with `requires_gem 'railties', '>= 5.0'`, so this cop must stay disabled
+/// for legacy Rails 3.x/4.x repos and repos without `railties` in
+/// `Gemfile.lock` even when external configs force `TargetRailsVersion`.
+///
+/// Include-gated to `spec/{controllers,requests}/**/*.rb` and
+/// `test/{controllers,integration}/**/*.rb` via rubocop-rails gem config;
+/// patterns resolve relative to base_dir (CWD for non-dotfile configs), so
+/// corpus runs must use `--repo-cwd` so CWD equals the repo root.
 pub struct ResponseParsedBody;
 
 impl Cop for ResponseParsedBody {
@@ -101,6 +105,11 @@ impl Cop for ResponseParsedBody {
             None => return,
         };
         if body_recv_call.name().as_slice() != b"response" {
+            return;
+        }
+        // RuboCop's pattern is `(send nil? :response)` — the `response` call
+        // itself must have no receiver. Reject `error.response.body` etc.
+        if body_recv_call.receiver().is_some() {
             return;
         }
 

--- a/tests/fixtures/cops/rails/response_parsed_body/no_offense.rb
+++ b/tests/fixtures/cops/rails/response_parsed_body/no_offense.rb
@@ -3,6 +3,9 @@ JSON.parse(data)
 JSON.parse(file.read)
 response.body
 JSON.parse(request.body)
+# RuboCop's node pattern requires `response` to have a nil receiver:
+# (send (const {nil? cbase} :JSON) :parse (send (send nil? :response) :body))
+JSON.parse(error.response.body)
 Nokogiri::XML(response.body)
 # Extra arguments — RuboCop only matches exactly 1 argument
 JSON.parse(response.body, symbolize_names: true)


### PR DESCRIPTION
## Summary
Fixed a false positive in the `ResponseParsedBody` cop where it was incorrectly flagging cases like `JSON.parse(error.response.body)` in request specs. The cop now properly validates that the `response` call has a nil receiver, matching RuboCop's node pattern requirements.

## Key Changes
- Added receiver validation: the `response` call must have no receiver (nil) to match the pattern `(send nil? :response)`. This prevents false positives on chained calls like `error.response.body`.
- Updated documentation to clarify the FP fix and explain the node pattern requirement
- Improved comments explaining the version gating and Include-gating behavior
- Added test case for `JSON.parse(error.response.body)` to the no_offense fixtures

## Implementation Details
The fix adds a simple check after validating the method name is "response":
```rust
if body_recv_call.receiver().is_some() {
    return;
}
```

This ensures we only match the specific pattern where `response` is called directly (with nil receiver), not when it's part of a longer method chain. The documentation was also clarified to explain that RuboCop's node pattern explicitly requires this nil receiver constraint.

https://claude.ai/code/session_01HxwecAzkW4s22dBsJKNujr