### PR TITLE
Fix schema discovery to match RuboCop's behavior for corpus runs

### DIFF
--- a/src/cop/rails/unique_validation_without_index.rs
+++ b/src/cop/rails/unique_validation_without_index.rs
@@ -1,7 +1,3 @@
-use std::collections::HashMap;
-use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
-
 use ruby_prism::Visit;
 
 use crate::cop::shared::node_type::CALL_NODE;
@@ -14,11 +10,14 @@ use crate::parse::source::SourceFile;
 /// Checks that uniqueness validations have a corresponding unique index
 /// on the database column(s). Requires schema analysis (db/schema.rb).
 ///
-/// Corpus runs invoke nitrocop with overlay configs that can place
-/// `config_dir()` outside the target repo. When that happens, the global schema
-/// singleton is unset because `db/schema.rb` is looked up in the wrong directory.
-/// This cop falls back to loading `db/schema.rb` relative to the current source
-/// file's repo root when the global schema is unavailable.
+/// Schema discovery must mirror RuboCop's `SchemaLoader#db_schema_path`,
+/// which walks up from `Pathname.pwd` and returns nil if no `db/schema.rb`
+/// is found before the filesystem root. Anchoring on the source file's
+/// directory instead overshoots: corpus runs invoke nitrocop from outside
+/// the repo (e.g., `cwd=/tmp`), where RuboCop loads no schema and the cop
+/// skips. A previous fallback that walked up from each source file caused
+/// 610 corpus FPs because nitrocop loaded the repo's schema in cases where
+/// RuboCop did not — see `crate::schema::init` for the matching walk.
 ///
 /// Corpus mismatches also showed two model-resolution gaps:
 /// nested model classes inside modules/classes were resolved as only the
@@ -35,41 +34,6 @@ use crate::parse::source::SourceFile;
 /// and nitrocop silently skip schema-dependent cops. The synthetic schema was
 /// fixed to use explicit `t.datetime "created_at"` columns instead.
 pub struct UniqueValidationWithoutIndex;
-
-/// Fallback schema loader that finds db/schema.rb relative to the source file's
-/// repo root when the global schema is unavailable.
-fn schema_for_source(source: &SourceFile) -> Option<&'static crate::schema::Schema> {
-    if let Some(schema) = crate::schema::get() {
-        return Some(schema);
-    }
-
-    static FALLBACK_SCHEMAS: OnceLock<
-        Mutex<HashMap<PathBuf, Option<&'static crate::schema::Schema>>>,
-    > = OnceLock::new();
-
-    let repo_root = source
-        .path
-        .ancestors()
-        .find(|path| path.join("db/schema.rb").is_file())?
-        .to_path_buf();
-
-    let mut cache = FALLBACK_SCHEMAS
-        .get_or_init(|| Mutex::new(HashMap::new()))
-        .lock()
-        .ok()?;
-
-    if let Some(schema) = cache.get(&repo_root).copied() {
-        return schema;
-    }
-
-    let schema = std::fs::read(repo_root.join("db/schema.rb"))
-        .ok()
-        .and_then(|bytes| crate::schema::Schema::parse(&bytes))
-        .map(|schema| Box::leak(Box::new(schema)) as &'static crate::schema::Schema);
-
-    cache.insert(repo_root, schema);
-    schema
-}
 
 const MSG: &str = "Uniqueness validation should have a unique index on the database column.";
 
@@ -99,7 +63,7 @@ impl Cop for UniqueValidationWithoutIndex {
         diagnostics: &mut Vec<Diagnostic>,
         _corrections: Option<&mut Vec<crate::correction::Correction>>,
     ) {
-        let schema = match schema_for_source(source) {
+        let schema = match crate::schema::get() {
             Some(s) => s,
             None => return,
         };

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -18,15 +18,29 @@ thread_local! {
     static TEST_SCHEMA: std::cell::RefCell<Option<Schema>> = const { std::cell::RefCell::new(None) };
 }
 
-/// Initialize the global schema from `db/schema.rb` relative to `project_root`.
+/// Initialize the global schema by walking up from `cwd` looking for
+/// `db/schema.rb`, mirroring RuboCop's `RuboCop::Rails::SchemaLoader#db_schema_path`
+/// which starts at `Pathname.pwd` and walks toward the filesystem root.
 ///
-/// Safe to call multiple times — only the first call takes effect.
-pub fn init(project_root: Option<&Path>) {
+/// Safe to call multiple times — only the first call takes effect. The
+/// `_legacy_root` argument is preserved for call-site compatibility but
+/// ignored; schema discovery is anchored to the current working directory
+/// to match RuboCop. Pinning to `cwd` is important for corpus runs where
+/// the user invokes nitrocop from outside the repo (e.g., `cwd=/tmp`):
+/// RuboCop returns no schema in that case and the cop skips, so nitrocop
+/// must skip too rather than walking up from each source file.
+pub fn init(_legacy_root: Option<&Path>) {
     SCHEMA.get_or_init(|| {
-        let root = project_root?;
-        let schema_path = root.join("db/schema.rb");
-        let bytes = std::fs::read(&schema_path).ok()?;
-        Schema::parse(&bytes)
+        let cwd = std::env::current_dir().ok()?;
+        let mut path = cwd.as_path();
+        loop {
+            let candidate = path.join("db/schema.rb");
+            if candidate.is_file() {
+                let bytes = std::fs::read(&candidate).ok()?;
+                return Schema::parse(&bytes);
+            }
+            path = path.parent()?;
+        }
     });
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5597,6 +5597,67 @@ fn force_default_config_ignores_config_file() {
     fs::remove_dir_all(&dir).ok();
 }
 
+#[test]
+fn unique_validation_without_index_only_loads_schema_relative_to_cwd() {
+    // RuboCop's SchemaLoader walks up from `Pathname.pwd` to find db/schema.rb
+    // and returns nil if none is found. Nitrocop must mirror that, otherwise
+    // corpus runs (cwd outside the repo) flag offenses RuboCop never emits.
+    let dir = temp_dir("unique_validation_schema_relative_to_cwd");
+    let outside_cwd = std::env::temp_dir().join("nitrocop_uvi_outside_cwd");
+    fs::create_dir_all(&outside_cwd).unwrap();
+    fs::create_dir_all(dir.join("app/models")).unwrap();
+    fs::create_dir_all(dir.join("db")).unwrap();
+    fs::write(
+        dir.join("app/models/label.rb"),
+        "class Label < ApplicationRecord\n  validates :name, uniqueness: true\nend\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("db/schema.rb"),
+        "ActiveRecord::Schema.define(version: 1) do\n  create_table \"labels\", force: :cascade do |t|\n    t.string \"name\"\n  end\nend\n",
+    )
+    .unwrap();
+
+    let from_outside = std::process::Command::new(env!("CARGO_BIN_EXE_nitrocop"))
+        .args([
+            "--preview",
+            "--force-default-config",
+            "--only",
+            "Rails/UniqueValidationWithoutIndex",
+            "--no-cache",
+            dir.to_str().unwrap(),
+        ])
+        .current_dir(&outside_cwd)
+        .output()
+        .expect("Failed to execute nitrocop");
+    let stdout_outside = String::from_utf8_lossy(&from_outside.stdout);
+    assert!(
+        !stdout_outside.contains("Rails/UniqueValidationWithoutIndex"),
+        "Schema must not be discovered when cwd has no db/schema.rb in any ancestor: {stdout_outside}"
+    );
+
+    let from_repo = std::process::Command::new(env!("CARGO_BIN_EXE_nitrocop"))
+        .args([
+            "--preview",
+            "--force-default-config",
+            "--only",
+            "Rails/UniqueValidationWithoutIndex",
+            "--no-cache",
+            dir.to_str().unwrap(),
+        ])
+        .current_dir(&dir)
+        .output()
+        .expect("Failed to execute nitrocop");
+    let stdout_repo = String::from_utf8_lossy(&from_repo.stdout);
+    assert!(
+        stdout_repo.contains("Rails/UniqueValidationWithoutIndex"),
+        "When cwd is the repo root, schema is loaded and the cop fires: {stdout_repo}"
+    );
+
+    fs::remove_dir_all(&dir).ok();
+    fs::remove_dir_all(&outside_cwd).ok();
+}
+
 // ---------- Autocorrect tests ----------
 
 #[test]


### PR DESCRIPTION
## Summary
This PR fixes the `Rails/UniqueValidationWithoutIndex` cop to correctly handle schema discovery when nitrocop is invoked from outside the target repository, matching RuboCop's behavior for corpus runs.

## Key Changes
- **Removed fallback schema loader**: Deleted the `schema_for_source()` function that walked up from each source file's directory to find `db/schema.rb`. This caused false positives in corpus runs where nitrocop would discover schemas that RuboCop never loaded.

- **Updated schema initialization**: Modified `schema::init()` to walk up from the current working directory (`cwd`) instead of a provided project root, mirroring RuboCop's `SchemaLoader#db_schema_path` behavior which starts at `Pathname.pwd`.

- **Simplified cop implementation**: Changed `UniqueValidationWithoutIndex` to use only the global schema via `crate::schema::get()`, removing the fallback logic.

- **Added integration test**: Added `unique_validation_without_index_only_loads_schema_relative_to_cwd()` to verify that:
  - When nitrocop runs from outside the repo, no schema is loaded and the cop doesn't fire
  - When nitrocop runs from within the repo, the schema is discovered and the cop fires correctly

## Implementation Details
The key insight is that corpus runs invoke nitrocop from outside the target repository (e.g., `cwd=/tmp`). RuboCop's schema loader anchors to `Pathname.pwd` and returns nil if no schema is found before the filesystem root. The previous implementation that walked up from each source file caused 610 false positives because it would discover schemas in cases where RuboCop did not.

By anchoring schema discovery to `cwd` instead, nitrocop now correctly skips the cop when running from outside the repo, matching RuboCop's behavior exactly.

https://claude.ai/code/session_015uPTuD1uDBy6PqnKLZmGnn