### PR TITLE
Expand reversible migration cop to check all db/ directories

### DIFF
--- a/src/cop/rails/reversible_migration_method_definition.rs
+++ b/src/cop/rails/reversible_migration_method_definition.rs
@@ -17,6 +17,8 @@ const MSG: &str =
 /// - The raw text superclass check overmatched bare `ActiveRecord::Migration`
 ///   and undermatched `::ActiveRecord::Migration[...]`, causing a large FP wave
 ///   and additional misses.
+/// - `default_include` was narrower than RuboCop's `db/**/*.rb`, so migrations
+///   under non-standard directories like `db/migrate_save/` were never checked.
 ///
 /// Fix: match RuboCop's versioned migration superclass shape
 /// (`ActiveRecord::Migration[6.0]` or `::ActiveRecord::Migration[6.0]`), count
@@ -105,7 +107,7 @@ impl Cop for ReversibleMigrationMethodDefinition {
     }
 
     fn default_include(&self) -> &'static [&'static str] {
-        &["db/migrate/**/*.rb"]
+        &["db/**/*.rb"]
     }
 
     fn interested_node_types(&self) -> &'static [u8] {


### PR DESCRIPTION
## Summary
Updated the `ReversibleMigrationMethodDefinition` cop to check all files under `db/` instead of only `db/migrate/`, aligning with RuboCop's default behavior and catching migrations in non-standard directories.

## Changes
- Modified `default_include` pattern from `db/migrate/**/*.rb` to `db/**/*.rb`
- Updated documentation to explain that the previous narrower pattern missed migrations in non-standard directories like `db/migrate_save/`

## Details
The cop was previously only checking migrations in the standard `db/migrate/` directory. This caused it to miss migrations stored in alternative locations that still follow Rails conventions. By expanding the pattern to match RuboCop's default `db/**/*.rb` pattern, the cop will now properly detect and validate reversible migration method definitions across all database-related directories.

https://claude.ai/code/session_01Nky8t9zvirBcWTTgAPCUU4