### PR TITLE
Fix Lint/UselessAssignment: OR LHS suppression + rescue retry FP

### DIFF
--- a/src/cop/lint/useless_assignment.rs
+++ b/src/cop/lint/useless_assignment.rs
@@ -587,19 +587,26 @@ impl<'pr> Visit<'pr> for PatternMatchTargetCollector {
 // In `if foo(x = 1) || foo(x = 2)`, short-circuit evaluation means only one
 // branch executes, but the VF engine sees both assignments as sequential in
 // the same scope. Suppress the LHS assignment when the same variable is also
-// assigned in the RHS of an `or`/`||` node.
+// assigned in the RHS of an `or`/`||` node AND the variable is read after the
+// OR — without a later read, both writes are genuinely useless and RuboCop
+// reports both (e.g. `(e = 0) == 0 || include?(e = 0)` with `e` never used).
 
 fn collect_or_condition_write_offsets(
     parse_result: &ruby_prism::ParseResult<'_>,
 ) -> HashSet<usize> {
-    let mut collector = OrConditionWriteCollector::default();
+    let mut read_collector = LvarReadOffsetCollector::default();
+    read_collector.visit(&parse_result.node());
+    let mut collector = OrConditionWriteCollector {
+        offsets: HashSet::new(),
+        reads_by_name: read_collector.reads_by_name,
+    };
     collector.visit(&parse_result.node());
     collector.offsets
 }
 
-#[derive(Default)]
 struct OrConditionWriteCollector {
     offsets: HashSet<usize>,
+    reads_by_name: HashMap<Vec<u8>, Vec<usize>>,
 }
 
 /// Helper visitor that collects all local variable write offsets within a subtree.
@@ -618,21 +625,45 @@ impl<'pr> Visit<'pr> for LvarWriteSubtreeCollector {
     }
 }
 
+#[derive(Default)]
+struct LvarReadOffsetCollector {
+    reads_by_name: HashMap<Vec<u8>, Vec<usize>>,
+}
+
+impl<'pr> Visit<'pr> for LvarReadOffsetCollector {
+    fn visit_local_variable_read_node(&mut self, node: &ruby_prism::LocalVariableReadNode<'pr>) {
+        self.reads_by_name
+            .entry(node.name().as_slice().to_vec())
+            .or_default()
+            .push(node.location().start_offset());
+    }
+}
+
 impl OrConditionWriteCollector {
     fn process_or_node(&mut self, node: &ruby_prism::OrNode<'_>) {
+        let or_end = node.location().end_offset();
         let mut lhs_collector = LvarWriteSubtreeCollector::default();
         lhs_collector.visit(&node.left());
         let mut rhs_collector = LvarWriteSubtreeCollector::default();
         rhs_collector.visit(&node.right());
 
         // For each variable written in LHS that is also written in RHS,
-        // suppress the LHS write offset.
+        // suppress the LHS write offset — but only when the variable is read
+        // after the OR. If the variable is never read after the OR, both
+        // writes are dead and should be reported.
         for (lhs_name, lhs_offset) in &lhs_collector.writes {
-            if rhs_collector
+            let rhs_writes_same = rhs_collector
                 .writes
                 .iter()
-                .any(|(rhs_name, _)| rhs_name == lhs_name)
-            {
+                .any(|(rhs_name, _)| rhs_name == lhs_name);
+            if !rhs_writes_same {
+                continue;
+            }
+            let read_after_or = self
+                .reads_by_name
+                .get(lhs_name)
+                .is_some_and(|offsets| offsets.iter().any(|&o| o >= or_end));
+            if read_after_or {
                 self.offsets.insert(*lhs_offset);
             }
         }

--- a/src/cop/lint/useless_assignment.rs
+++ b/src/cop/lint/useless_assignment.rs
@@ -154,6 +154,8 @@ impl Cop for UselessAssignment {
         let or_condition_offsets = collect_or_condition_write_offsets(parse_result);
         let post_condition_loop_body_offsets =
             collect_post_condition_loop_body_write_offsets(parse_result);
+        let retry_protected_rescue_offsets =
+            collect_retry_protected_rescue_capture_offsets(parse_result);
         let mut rescue_modifier_collector = RescueModifierWriteCollector::default();
         rescue_modifier_collector.visit(&parse_result.node());
         let mut rescue_modifier_offsets = rescue_modifier_collector.offsets;
@@ -178,6 +180,7 @@ impl Cop for UselessAssignment {
                     && !or_condition_offsets.contains(&candidate.node_offset)
                     && !post_condition_loop_body_offsets.contains(&candidate.node_offset)
                     && !rescue_modifier_offsets.contains(&candidate.node_offset)
+                    && !retry_protected_rescue_offsets.contains(&candidate.node_offset)
             } else {
                 false
             };
@@ -833,6 +836,185 @@ impl<'pr> Visit<'pr> for RescueModifierPrecedingWriteCollector<'_> {
             self.offsets.insert(node.location().start_offset());
         }
         ruby_prism::visit_local_variable_write_node(self, node);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FP suppression: rescue exception captures protected by a sibling retry-rescue
+// ---------------------------------------------------------------------------
+//
+// RuboCop's `process_rescue` treats a `begin ... rescue ... end` containing
+// `retry` as a loop, which (combined with the variable_force walk) keeps any
+// `rescue X => e` capture of the same name alive across the entire surrounding
+// scope — even captures in other begin blocks that don't themselves use `e`.
+//
+// Mirror that quirk: when one `rescue X => name` clause in a scope (def/class/
+// module/lambda or top-level) contains both `retry` and a read of `name`,
+// suppress the unused-warning for every rescue capture of that name in the
+// same scope.
+
+fn collect_retry_protected_rescue_capture_offsets(
+    parse_result: &ruby_prism::ParseResult<'_>,
+) -> HashSet<usize> {
+    let mut collector = RetryProtectedRescueCollector::default();
+    collector.visit(&parse_result.node());
+    let mut suppress_collector = RetryProtectedSuppressCollector {
+        protected: &collector.protected,
+        scope_stack: vec![0],
+        offsets: HashSet::new(),
+    };
+    suppress_collector.visit(&parse_result.node());
+    suppress_collector.offsets
+}
+
+#[derive(Default)]
+struct RetryProtectedRescueCollector {
+    /// (scope_offset, name) pairs where a rescue clause uses `name` and contains retry.
+    protected: HashSet<(usize, Vec<u8>)>,
+    scope_stack: Vec<usize>,
+}
+
+impl RetryProtectedRescueCollector {
+    fn current_scope(&self) -> usize {
+        self.scope_stack.last().copied().unwrap_or(0)
+    }
+
+    fn enter_scope<F: FnOnce(&mut Self)>(&mut self, offset: usize, f: F) {
+        self.scope_stack.push(offset);
+        f(self);
+        self.scope_stack.pop();
+    }
+}
+
+fn rescue_clause_capture_name(rescue: &ruby_prism::RescueNode<'_>) -> Option<Vec<u8>> {
+    let reference = rescue.reference()?;
+    let target = reference.as_local_variable_target_node()?;
+    Some(target.name().as_slice().to_vec())
+}
+
+fn rescue_clause_capture_offset(rescue: &ruby_prism::RescueNode<'_>) -> Option<usize> {
+    let reference = rescue.reference()?;
+    let target = reference.as_local_variable_target_node()?;
+    Some(target.location().start_offset())
+}
+
+fn rescue_clause_body_has_retry_and_read(rescue: &ruby_prism::RescueNode<'_>, name: &[u8]) -> bool {
+    let Some(stmts) = rescue.statements() else {
+        return false;
+    };
+    let mut scanner = RetryAndReadScanner {
+        name,
+        has_retry: false,
+        has_read: false,
+    };
+    for stmt in stmts.body().iter() {
+        scanner.visit(&stmt);
+    }
+    scanner.has_retry && scanner.has_read
+}
+
+struct RetryAndReadScanner<'n> {
+    name: &'n [u8],
+    has_retry: bool,
+    has_read: bool,
+}
+
+impl<'pr> Visit<'pr> for RetryAndReadScanner<'_> {
+    fn visit_retry_node(&mut self, _node: &ruby_prism::RetryNode<'pr>) {
+        self.has_retry = true;
+    }
+    fn visit_local_variable_read_node(&mut self, node: &ruby_prism::LocalVariableReadNode<'pr>) {
+        if node.name().as_slice() == self.name {
+            self.has_read = true;
+        }
+    }
+    // Don't recurse into nested scopes — local var resolution doesn't cross
+    // those boundaries for rescue exception captures.
+    fn visit_def_node(&mut self, _: &ruby_prism::DefNode<'pr>) {}
+    fn visit_class_node(&mut self, _: &ruby_prism::ClassNode<'pr>) {}
+    fn visit_module_node(&mut self, _: &ruby_prism::ModuleNode<'pr>) {}
+    fn visit_lambda_node(&mut self, _: &ruby_prism::LambdaNode<'pr>) {}
+}
+
+impl<'pr> Visit<'pr> for RetryProtectedRescueCollector {
+    fn visit_def_node(&mut self, node: &ruby_prism::DefNode<'pr>) {
+        let offset = node.location().start_offset();
+        self.enter_scope(offset, |this| ruby_prism::visit_def_node(this, node));
+    }
+
+    fn visit_class_node(&mut self, node: &ruby_prism::ClassNode<'pr>) {
+        let offset = node.location().start_offset();
+        self.enter_scope(offset, |this| ruby_prism::visit_class_node(this, node));
+    }
+
+    fn visit_module_node(&mut self, node: &ruby_prism::ModuleNode<'pr>) {
+        let offset = node.location().start_offset();
+        self.enter_scope(offset, |this| ruby_prism::visit_module_node(this, node));
+    }
+
+    fn visit_lambda_node(&mut self, node: &ruby_prism::LambdaNode<'pr>) {
+        let offset = node.location().start_offset();
+        self.enter_scope(offset, |this| ruby_prism::visit_lambda_node(this, node));
+    }
+
+    fn visit_rescue_node(&mut self, node: &ruby_prism::RescueNode<'pr>) {
+        if let Some(name) = rescue_clause_capture_name(node) {
+            if rescue_clause_body_has_retry_and_read(node, &name) {
+                self.protected.insert((self.current_scope(), name));
+            }
+        }
+        ruby_prism::visit_rescue_node(self, node);
+    }
+}
+
+struct RetryProtectedSuppressCollector<'a> {
+    protected: &'a HashSet<(usize, Vec<u8>)>,
+    scope_stack: Vec<usize>,
+    offsets: HashSet<usize>,
+}
+
+impl<'a> RetryProtectedSuppressCollector<'a> {
+    fn current_scope(&self) -> usize {
+        self.scope_stack.last().copied().unwrap_or(0)
+    }
+
+    fn enter_scope<F: FnOnce(&mut Self)>(&mut self, offset: usize, f: F) {
+        self.scope_stack.push(offset);
+        f(self);
+        self.scope_stack.pop();
+    }
+}
+
+impl<'pr> Visit<'pr> for RetryProtectedSuppressCollector<'_> {
+    fn visit_def_node(&mut self, node: &ruby_prism::DefNode<'pr>) {
+        let offset = node.location().start_offset();
+        self.enter_scope(offset, |this| ruby_prism::visit_def_node(this, node));
+    }
+
+    fn visit_class_node(&mut self, node: &ruby_prism::ClassNode<'pr>) {
+        let offset = node.location().start_offset();
+        self.enter_scope(offset, |this| ruby_prism::visit_class_node(this, node));
+    }
+
+    fn visit_module_node(&mut self, node: &ruby_prism::ModuleNode<'pr>) {
+        let offset = node.location().start_offset();
+        self.enter_scope(offset, |this| ruby_prism::visit_module_node(this, node));
+    }
+
+    fn visit_lambda_node(&mut self, node: &ruby_prism::LambdaNode<'pr>) {
+        let offset = node.location().start_offset();
+        self.enter_scope(offset, |this| ruby_prism::visit_lambda_node(this, node));
+    }
+
+    fn visit_rescue_node(&mut self, node: &ruby_prism::RescueNode<'pr>) {
+        if let Some(name) = rescue_clause_capture_name(node) {
+            if self.protected.contains(&(self.current_scope(), name)) {
+                if let Some(offset) = rescue_clause_capture_offset(node) {
+                    self.offsets.insert(offset);
+                }
+            }
+        }
+        ruby_prism::visit_rescue_node(self, node);
     }
 }
 

--- a/tests/fixtures/cops/lint/useless_assignment/no_offense.rb
+++ b/tests/fixtures/cops/lint/useless_assignment/no_offense.rb
@@ -697,3 +697,28 @@ def modifier_if_nested_write(recursive:)
   recursive = [recursive -= 1, 0].max if recursive.is_a?(Integer)
   recursive
 end
+
+# FP fix: rescue exception captures protected by sibling retry-rescue.
+# RuboCop's `process_rescue` treats a `begin ... rescue ... end` containing
+# `retry` as a loop. When one rescue clause in the scope uses the captured
+# variable AND contains `retry`, every same-name capture in the scope stays
+# live — even one in a sibling begin block whose body is just `retry`.
+# Mirrors the Netflix-Skunkworks Scumblr `github_sync.rb#get_repos` pattern.
+def retry_protected_rescue_capture(name, type)
+  if type == "org"
+    begin
+      response = work(name)
+    rescue Foo => e
+      retry
+    end
+  else
+    begin
+      response = work(name)
+    rescue Foo => e
+      handle_rate_limit(e)
+      retry
+    rescue => e
+    end
+  end
+  response
+end

--- a/tests/fixtures/cops/lint/useless_assignment/offense.rb
+++ b/tests/fixtures/cops/lint/useless_assignment/offense.rb
@@ -450,3 +450,23 @@ m_over_c   = (statistics.methods / statistics.classes) rescue m_over_c = 0
 
 loc_over_m = (statistics.code_lines / statistics.methods) - 2 rescue loc_over_m = 0
 ^ Lint/UselessAssignment: Useless assignment to variable - `loc_over_m`.
+
+# FN fix: OR-condition LHS write should still be reported when the variable is
+# never read after the OR. Suppression of the LHS exists for the case where
+# the variable is read after the OR (short-circuit kept the LHS write live);
+# without a later read, both writes are dead. Mirrors discourse `plurals.rb`
+# `(e = 0) == 0 ... || !(0..5).include?(e = 0)` in a lambda body that returns
+# a symbol.
+def or_condition_writes_no_later_read(n)
+  if (
+       (
+         (e = 0) == 0 && n.to_i != 0
+          ^ Lint/UselessAssignment: Useless assignment to variable - `e`.
+       ) || !(0..5).include?(e = 0)
+                             ^ Lint/UselessAssignment: Useless assignment to variable - `e`.
+     )
+    :many
+  else
+    :other
+  end
+end


### PR DESCRIPTION
## Summary
Two RuboCop-compatibility fixes for `Lint/UselessAssignment`.

**FN: OR LHS suppression too broad.** The post-pass that suppressed LHS writes inside `lhs || rhs` whenever the same variable was written on both sides ran unconditionally. That hid real offenses like discourse `plurals.rb` `(e = 0) == 0 ... || include?(e = 0)` where neither write is read after the OR. Now suppression is gated on a later read.

**FP: rescue captures protected by sibling retry-rescue.** RuboCop's `process_rescue` treats `begin ... rescue ... end` containing `retry` as a loop, which (combined with the variable_force walk) keeps every same-name capture alive in the surrounding scope when one rescue clause uses `e` AND contains `retry`. Mirror the quirk: collect (scope, name) pairs from retry+self-ref rescues, then suppress every same-name rescue capture in the scope.

Targets:
- 5 FNs in `discourse__discourse__9c8f125: config/locales/plurals.rb` (lines 568, 689, 1050, 1812, 1835).
- 1 FP in `Netflix-Skunkworks__Scumblr__66ed69a: lib/scumblr_tasks/sync_tasks/github_sync.rb:168` (and similar patterns).

## Test plan
- [x] `cargo test --release --lib -- cop::lint::useless_assignment` passes
- [x] Existing OR-condition no_offense fixtures still pass
- [x] New offense fixture for OR-no-later-read
- [x] New no_offense fixture for retry-protected rescue captures
- [x] Verified locally against the actual Scumblr file: 0 offenses (matches RuboCop)
- [ ] CI corpus check confirms no regressions