### PR TITLE
Fix Style/MethodCallWithArgsParentheses default + omit_parentheses divergences

### DIFF
--- a/src/cop/style/method_call_with_args_parentheses.rs
+++ b/src/cop/style/method_call_with_args_parentheses.rs
@@ -466,6 +466,26 @@ use crate::parse::source::SourceFile;
 ///    depth at `1` for value-omission calls inside the block. Reset
 ///    `non_last_expression_depth` at every block/lambda body entry so each
 ///    block body computes value-omission siblings independently.
+///
+/// ## Variant fix follow-up (2026-04-26): record block source span
+///
+/// The `non_last_expression_depth` reset above introduced ~800 new FP on
+/// hash-value-omission calls inside SINGLE-LINE blocks
+/// (`let(:x) { create(:y, foo:) }`, `.map { |x| Foo.new(x:) }`). Before the
+/// reset, the leaked outer depth happened to make
+/// `require_parentheses_for_hash_value_omission?` return true via the
+/// `!last_expression?` branch — incidentally agreeing with RuboCop, which
+/// allows the parens via `node.parent&.single_line?` (the block is
+/// single-line). With the depth reset, that incidental allowance went away.
+///
+/// Implement the actual `parent.single_line?` semantics: push every
+/// `ParentKind::Block` / `ParentKind::CallLikeBlockBody` WITH the block
+/// node's source span. `parent_is_single_line()` then returns true for
+/// braced single-line block parents and false for `do ... end` multi-line
+/// blocks, matching RuboCop. Threaded through `visit_node_with_parent`
+/// and `visit_statements_with_parent` via `_loc` variants that accept an
+/// `Option<(usize, usize)>` location for the synthetic `CallLikeBlockBody`
+/// boundary.
 pub struct MethodCallWithArgsParentheses;
 
 /// Check if a method name matches any pattern in the list (regex-style).
@@ -797,6 +817,15 @@ impl ParenVisitor<'_> {
         node: &ruby_prism::StatementsNode<'pr>,
         parent_kind: ParentKind,
     ) {
+        self.visit_statements_with_parent_loc(node, parent_kind, None);
+    }
+
+    fn visit_statements_with_parent_loc<'pr>(
+        &mut self,
+        node: &ruby_prism::StatementsNode<'pr>,
+        parent_kind: ParentKind,
+        parent_loc: Option<(usize, usize)>,
+    ) {
         let body = node.body();
         let single_statement = body.len() == 1;
         let can_inherit_direct_parent = single_statement
@@ -822,7 +851,12 @@ impl ParenVisitor<'_> {
             }
 
             if can_inherit_direct_parent {
-                self.push_parent(parent_kind);
+                if let Some((start, end)) = parent_loc {
+                    self.parent_stack.push(parent_kind);
+                    self.parent_loc_stack.push(Some((start, end)));
+                } else {
+                    self.push_parent(parent_kind);
+                }
             }
             self.visit(&stmt);
             if can_inherit_direct_parent {
@@ -839,15 +873,21 @@ impl ParenVisitor<'_> {
         }
     }
 
-    fn visit_node_with_parent<'pr>(
+    fn visit_node_with_parent_loc<'pr>(
         &mut self,
         node: &ruby_prism::Node<'pr>,
         parent_kind: ParentKind,
+        parent_loc: Option<(usize, usize)>,
     ) {
         if let Some(stmts) = node.as_statements_node() {
-            self.visit_statements_with_parent(&stmts, parent_kind);
+            self.visit_statements_with_parent_loc(&stmts, parent_kind, parent_loc);
         } else if node.as_begin_node().is_none() {
-            self.push_parent(parent_kind);
+            if let Some((start, end)) = parent_loc {
+                self.parent_stack.push(parent_kind);
+                self.parent_loc_stack.push(Some((start, end)));
+            } else {
+                self.push_parent(parent_kind);
+            }
             self.visit(node);
             self.pop_parent();
         } else {
@@ -1748,7 +1788,9 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
                     } else {
                         None
                     };
-                    self.push_parent(ParentKind::Block);
+                    let block_loc = block_node.location();
+                    let block_loc_pair = (block_loc.start_offset(), block_loc.end_offset());
+                    self.push_parent_with_loc(ParentKind::Block, block_loc);
                     self.push_macro_scope(child_scope);
                     if let Some(params) = block_node.parameters() {
                         self.visit(&params);
@@ -1759,7 +1801,11 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
                         let prev_non_last_expression_depth = self.non_last_expression_depth;
                         self.non_last_expression_depth = 0;
                         if block_parent_is_call_like {
-                            self.visit_node_with_parent(&body, ParentKind::CallLikeBlockBody);
+                            self.visit_node_with_parent_loc(
+                                &body,
+                                ParentKind::CallLikeBlockBody,
+                                Some(block_loc_pair),
+                            );
                         } else {
                             self.visit(&body);
                         }
@@ -1872,7 +1918,9 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
             None
         };
 
-        self.push_parent(ParentKind::Block);
+        let block_loc = node.location();
+        let block_loc_pair = (block_loc.start_offset(), block_loc.end_offset());
+        self.push_parent_with_loc(ParentKind::Block, block_loc);
         let child_scope = self.wrapper_child_scope();
         self.push_macro_scope(child_scope);
         if let Some(params) = node.parameters() {
@@ -1889,7 +1937,11 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
             let prev_non_last_expression_depth = self.non_last_expression_depth;
             self.non_last_expression_depth = 0;
             if block_parent_is_call_like {
-                self.visit_node_with_parent(&body, ParentKind::CallLikeBlockBody);
+                self.visit_node_with_parent_loc(
+                    &body,
+                    ParentKind::CallLikeBlockBody,
+                    Some(block_loc_pair),
+                );
             } else {
                 self.visit(&body);
             }
@@ -1938,7 +1990,9 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
             None
         };
 
-        self.push_parent(ParentKind::Block);
+        let block_loc = node.location();
+        let block_loc_pair = (block_loc.start_offset(), block_loc.end_offset());
+        self.push_parent_with_loc(ParentKind::Block, block_loc);
         self.push_macro_scope(child_scope);
         if let Some(body) = node.body() {
             // Same reset as `visit_block_node`: each lambda body computes
@@ -1947,7 +2001,11 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
             let prev_non_last_expression_depth = self.non_last_expression_depth;
             self.non_last_expression_depth = 0;
             if block_parent_is_call_like {
-                self.visit_node_with_parent(&body, ParentKind::CallLikeBlockBody);
+                self.visit_node_with_parent_loc(
+                    &body,
+                    ParentKind::CallLikeBlockBody,
+                    Some(block_loc_pair),
+                );
             } else {
                 self.visit(&body);
             }
@@ -2005,7 +2063,9 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
                     None
                 };
 
-                self.push_parent(ParentKind::Block);
+                let block_loc = block_node.location();
+                let block_loc_pair = (block_loc.start_offset(), block_loc.end_offset());
+                self.push_parent_with_loc(ParentKind::Block, block_loc);
                 self.push_macro_scope(child_scope);
                 if let Some(params) = block_node.parameters() {
                     self.visit(&params);
@@ -2016,7 +2076,11 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
                     let prev_non_last_expression_depth = self.non_last_expression_depth;
                     self.non_last_expression_depth = 0;
                     if block_parent_is_call_like {
-                        self.visit_node_with_parent(&body, ParentKind::CallLikeBlockBody);
+                        self.visit_node_with_parent_loc(
+                            &body,
+                            ParentKind::CallLikeBlockBody,
+                            Some(block_loc_pair),
+                        );
                     } else {
                         self.visit(&body);
                     }

--- a/src/cop/style/method_call_with_args_parentheses.rs
+++ b/src/cop/style/method_call_with_args_parentheses.rs
@@ -419,6 +419,53 @@ use crate::parse::source::SourceFile;
 ///    else statements, so `else resize_to_limit_options(width, height) end
 ///    .transform_values!` was treated as a chain argument. Pop and restore
 ///    the outer call-like parent in both case visitors.
+///
+/// ## Variant fix (2026-04-26, oracle: 458 FP / 8,423 FN + default 0 FP / 2 FN)
+///
+/// Four narrower divergences remained on the latest oracle:
+///
+/// 1. **Default-config FN regression in `visit_begin_node`.** The previous
+///    fix that pops an outer `Call`/`CallAssignedRhs`/`Super` parent at begin
+///    entry also caused `nested_in_non_wrapper()` to read a parent_stack with
+///    the leaked parent already gone. For
+///    `Foo.config.x = begin ...; raise "msg"; ...; end`, that meant the
+///    surrounding setter's `Call` parent vanished before the wrapper-vs-non-
+///    wrapper decision, so the begin's child scope inherited macro scope from
+///    top level and `raise "msg"`/`puts "..."` were silently treated as
+///    macros. Fixed by capturing `nested_in_non_wrapper()` BEFORE popping
+///    `leaked_parent`.
+///
+/// 2. **`assignment_in_condition?` missed ternary branches.** RuboCop's
+///    `grandparent.conditional?` is true for ternary `if` nodes, so
+///    `value = ref.is_tagged_with?(...)` inside `cond ? ... : value = ...`
+///    keeps its parens. nitrocop only matched `Conditional`/`ConditionalBody`/
+///    `When`/`WhenBody` as the grandparent. Added `TernaryBranch` so ternary
+///    `:` branches with assignment RHSs no longer false-positive.
+///
+/// 3. **Multi-statement `when`/`if`/`else` bodies leaked outer
+///    `ConditionalBody`/`WhenBody` as the assignment grandparent.** Parser AST
+///    wraps multi-statement bodies in a synthetic `:begin`. RuboCop's
+///    `assignment_in_condition?` then sees the begin (not a conditional/when)
+///    as grandparent and returns false. nitrocop's
+///    `visit_statements_with_parent` only pushed the parent kind for SINGLE-
+///    statement bodies, leaving multi-statement bodies to inherit whatever
+///    parent the surrounding `if`/`case` carried. So
+///    `case x; when :a; lvasgn1; lvasgn2 = call(...); ...; end` inside an
+///    enclosing `if cond ... end` falsely matched
+///    `Assignment + ConditionalBody` and skipped the offense. Added a
+///    `ParentKind::Begin` boundary marker pushed for multi-statement bodies
+///    in both `visit_statements_node` and `visit_statements_with_parent`
+///    (and added it to `nested_in_non_wrapper`'s wrapper exempt list because
+///    `:begin`/`:kwbegin` ARE wrappers in `in_macro_scope?`).
+///
+/// 4. **`non_last_expression_depth` leaked through block bodies.** RuboCop's
+///    `last_expression?` only inspects the call's immediate right sibling
+///    (or the right sibling of its assignment parent). nitrocop tracked a
+///    depth counter that only reset at `def` body entry, so an outer
+///    non-last `if` statement above a `.map do ... end` block kept the
+///    depth at `1` for value-omission calls inside the block. Reset
+///    `non_last_expression_depth` at every block/lambda body entry so each
+///    block body computes value-omission siblings independently.
 pub struct MethodCallWithArgsParentheses;
 
 /// Check if a method name matches any pattern in the list (regex-style).
@@ -522,6 +569,15 @@ enum ParentKind {
     /// so callers nested inside the block must not see the surrounding
     /// expression's parent as their grandparent.
     Block,
+    /// Synthetic begin marker pushed for multi-statement bodies (def/block/
+    /// when/if/else/etc.). Parser AST wraps multi-statement bodies as a
+    /// `:begin` node. RuboCop's `assignment_in_condition?` therefore sees a
+    /// begin (not the surrounding conditional/when) as the grandparent of an
+    /// inner assignment. This marker reproduces that boundary so outer
+    /// `ConditionalBody`/`WhenBody`/etc. don't leak across multi-statement
+    /// lists. `:begin`/`:kwbegin` ARE wrappers in `in_macro_scope?`, so this
+    /// kind is included in `nested_in_non_wrapper`'s exempt list.
+    Begin,
 }
 
 impl Cop for MethodCallWithArgsParentheses {
@@ -731,6 +787,7 @@ impl ParenVisitor<'_> {
                     | ParentKind::ConditionalBody
                     | ParentKind::WhenBody
                     | ParentKind::Block
+                    | ParentKind::Begin
             )
         })
     }
@@ -747,6 +804,16 @@ impl ParenVisitor<'_> {
                 .iter()
                 .next()
                 .is_some_and(|stmt| stmt.as_begin_node().is_none());
+
+        // Multi-statement bodies wrap as `:begin` in Parser AST. Push the
+        // synthetic boundary so descendants don't see the surrounding
+        // ConditionalBody/WhenBody as their grandparent in
+        // `assignment_in_condition`. Single-statement bodies (or a single
+        // begin child) keep the existing behavior.
+        let pushed_begin = !can_inherit_direct_parent && body.len() > 1;
+        if pushed_begin {
+            self.push_parent(ParentKind::Begin);
+        }
 
         for (index, stmt) in body.iter().enumerate() {
             let is_not_last = index + 1 < body.len();
@@ -765,6 +832,10 @@ impl ParenVisitor<'_> {
             if is_not_last {
                 self.non_last_expression_depth -= 1;
             }
+        }
+
+        if pushed_begin {
+            self.pop_parent();
         }
     }
 
@@ -1209,6 +1280,10 @@ impl ParenVisitor<'_> {
                         | ParentKind::ConditionalBody
                         | ParentKind::When
                         | ParentKind::WhenBody
+                        // Ternary `if` nodes are `conditional?` in RuboCop, so
+                        // `value = call(...)` inside `cond ? ... : value = call(...)`
+                        // keeps its parens via assignment_in_condition?.
+                        | ParentKind::TernaryBranch
                 )
             {
                 return true;
@@ -1594,6 +1669,13 @@ fn is_ambiguous_descendant(node: &ruby_prism::Node<'_>, source: &SourceFile) -> 
 impl<'pr> Visit<'pr> for ParenVisitor<'_> {
     fn visit_statements_node(&mut self, node: &ruby_prism::StatementsNode<'pr>) {
         let body = node.body();
+        // Multi-statement bodies wrap as `:begin` in Parser AST. Push a
+        // synthetic boundary marker so an outer ConditionalBody/WhenBody
+        // doesn't leak through as the grandparent of an inner assignment.
+        let pushed_begin = body.len() > 1;
+        if pushed_begin {
+            self.push_parent(ParentKind::Begin);
+        }
         for (index, stmt) in body.iter().enumerate() {
             let is_not_last = index + 1 < body.len();
             if is_not_last {
@@ -1603,6 +1685,9 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
             if is_not_last {
                 self.non_last_expression_depth -= 1;
             }
+        }
+        if pushed_begin {
+            self.pop_parent();
         }
     }
 
@@ -1669,11 +1754,16 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
                         self.visit(&params);
                     }
                     if let Some(body) = block_node.body() {
+                        // Reset non_last_expression_depth at block body entry
+                        // (mirrors `visit_block_node`/`visit_lambda_node`).
+                        let prev_non_last_expression_depth = self.non_last_expression_depth;
+                        self.non_last_expression_depth = 0;
                         if block_parent_is_call_like {
                             self.visit_node_with_parent(&body, ParentKind::CallLikeBlockBody);
                         } else {
                             self.visit(&body);
                         }
+                        self.non_last_expression_depth = prev_non_last_expression_depth;
                     }
                     self.pop_scope();
                     self.pop_parent();
@@ -1789,11 +1879,21 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
             self.visit(&params);
         }
         if let Some(body) = node.body() {
+            // Reset non_last_expression_depth so an outer non-last sibling
+            // (e.g., the `if` above a `.map do ... end`) doesn't make
+            // `Foo.bar(value:)` inside the block falsely pass
+            // `require_parentheses_for_hash_value_omission?` via the
+            // `!last_expression?` branch. RuboCop only checks the call's own
+            // (or its assignment parent's) right sibling, which restarts
+            // inside each block body.
+            let prev_non_last_expression_depth = self.non_last_expression_depth;
+            self.non_last_expression_depth = 0;
             if block_parent_is_call_like {
                 self.visit_node_with_parent(&body, ParentKind::CallLikeBlockBody);
             } else {
                 self.visit(&body);
             }
+            self.non_last_expression_depth = prev_non_last_expression_depth;
         }
         self.pop_scope();
         self.pop_parent();
@@ -1841,11 +1941,17 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
         self.push_parent(ParentKind::Block);
         self.push_macro_scope(child_scope);
         if let Some(body) = node.body() {
+            // Same reset as `visit_block_node`: each lambda body computes
+            // value-omission siblings independently, so the surrounding
+            // expression's non-last-sibling depth must not leak in.
+            let prev_non_last_expression_depth = self.non_last_expression_depth;
+            self.non_last_expression_depth = 0;
             if block_parent_is_call_like {
                 self.visit_node_with_parent(&body, ParentKind::CallLikeBlockBody);
             } else {
                 self.visit(&body);
             }
+            self.non_last_expression_depth = prev_non_last_expression_depth;
         }
         self.pop_scope();
         self.pop_parent();
@@ -1905,11 +2011,16 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
                     self.visit(&params);
                 }
                 if let Some(body) = block_node.body() {
+                    // Reset non_last_expression_depth at block body entry
+                    // (mirrors `visit_block_node`/`visit_lambda_node`).
+                    let prev_non_last_expression_depth = self.non_last_expression_depth;
+                    self.non_last_expression_depth = 0;
                     if block_parent_is_call_like {
                         self.visit_node_with_parent(&body, ParentKind::CallLikeBlockBody);
                     } else {
                         self.visit(&body);
                     }
+                    self.non_last_expression_depth = prev_non_last_expression_depth;
                 }
                 self.pop_scope();
                 self.pop_parent();
@@ -1927,6 +2038,13 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
 
     fn visit_begin_node(&mut self, node: &ruby_prism::BeginNode<'pr>) {
         let has_rescue_or_ensure = node.rescue_clause().is_some() || node.ensure_clause().is_some();
+
+        // Capture `nested_in_non_wrapper` BEFORE popping the leaked parent so
+        // the begin's wrapper-vs-non-wrapper decision still sees the surrounding
+        // setter/chained call. Otherwise `Foo.bar = begin ...; raise "x"; end`
+        // would treat the begin as a fresh wrapper and silently exempt inner
+        // receiverless calls as macros.
+        let begin_nested_in_non_wrapper = self.nested_in_non_wrapper();
 
         // In Parser AST, statements inside `begin ... end` (with or without
         // rescue/ensure) have the (kw)begin node as their direct parent, NOT
@@ -1974,7 +2092,7 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
             // Pure `begin...end` (no rescue/ensure) — `kwbegin` is a wrapper
             // in RuboCop's `in_macro_scope?`, but only when the whole begin
             // expression is itself in macro scope.
-            let child_scope = if self.nested_in_non_wrapper() {
+            let child_scope = if begin_nested_in_non_wrapper {
                 MacroScope::NotMacroScope
             } else {
                 self.wrapper_child_scope()

--- a/tests/fixtures/cops/style/method_call_with_args_parentheses/no_offense.omit_parentheses.rb
+++ b/tests/fixtures/cops/style/method_call_with_args_parentheses/no_offense.omit_parentheses.rb
@@ -62,3 +62,16 @@ module Clusters
     end
   end
 end
+
+# Ternary `else` branch carrying an assignment whose RHS is a parenthesized
+# call. RuboCop's `assignment_in_condition?` allows the parens because the
+# surrounding ternary is `conditional?`. The grandparent in nitrocop's
+# parent_stack is `TernaryBranch`, which must satisfy the same allowance.
+def self._subst(rec, opts, tag, mode)
+  case mode.downcase
+  when "exist"
+    ref.nil? ? value = false : value = ref.is_tagged_with?(tag, :ns => "*")
+  when "registry"
+    ref.nil? ? value = "" : value = registry_data(ref, tag, ohash)
+  end
+end

--- a/tests/fixtures/cops/style/method_call_with_args_parentheses/no_offense.omit_parentheses.rb
+++ b/tests/fixtures/cops/style/method_call_with_args_parentheses/no_offense.omit_parentheses.rb
@@ -75,3 +75,26 @@ def self._subst(rec, opts, tag, mode)
     ref.nil? ? value = "" : value = registry_data(ref, tag, ohash)
   end
 end
+
+# Hash-value-omission inside a single-line block keeps parens via
+# `node.parent&.single_line?`. The Block / CallLikeBlockBody parent must
+# carry the block's source span so `parent_is_single_line()` returns true
+# for `let(:x) { create(:y, foo:) }`-style spec helpers and inline
+# `.map { |x| Foo.new(x:) }` chains.
+RSpec.describe Favorites::ForUser do
+  let!(:cluster) { create(:cluster, account:) }
+  let!(:project) { create(:project, cluster:, account:) }
+  let(:component) { Component.new(name:, label:, input_type:, params:) }
+end
+
+class Theme
+  def self.default_themes
+    DEFAULT_THEMES.map { |name, icon| new(name:, icon:) }
+  end
+end
+
+def points_creator
+  payload = data
+            .compact
+            .map { |location| location.merge(user_id:) }
+end

--- a/tests/fixtures/cops/style/method_call_with_args_parentheses/offense.omit_parentheses.rb
+++ b/tests/fixtures/cops/style/method_call_with_args_parentheses/offense.omit_parentheses.rb
@@ -84,3 +84,41 @@ add_alchemy_filter :by_file_type, type: :select, options: ->(_query, params) do
                          ^^^^^^^^^^^^^^^^^^^^^^^ Style/MethodCallWithArgsParentheses: Omit parentheses for method calls with arguments.
   end
 end
+
+# Hash-value-omission inside a block whose surrounding expression is a
+# non-call (here `||=` op-assignment): RuboCop's call_in_argument_with_block?
+# rejects the outer or-asgn, and require_parentheses_for_hash_value_omission?
+# falls through because the call IS the last expression in the block body.
+# Earlier nitrocop kept these parens because the outer non-last `if` leaked a
+# non-zero `non_last_expression_depth` into the block body.
+def search_filter_params
+  @cache ||= begin
+    a = 1
+
+    if cond
+      bar[:k] ||= [1, 2, 3].map do |extension|
+        Marcel::MimeType.for(extension:)
+                            ^^^^^^^^^^^^ Style/MethodCallWithArgsParentheses: Omit parentheses for method calls with arguments.
+      end
+    end
+
+    z
+  end
+end
+
+# Multi-statement when body wraps as a synthetic `:begin` in Parser AST. The
+# inner lvasgn's grandparent in RuboCop is the synthetic begin, NOT the
+# outer `if`'s ConditionalBody, so `assignment_in_condition?` returns false
+# and the call still flags. Earlier nitrocop let `ConditionalBody` leak
+# through as the lvasgn's grandparent.
+def picture_factory(picture, acc)
+  if acc.image_file
+    case Alchemy.storage_adapter.name
+    when :active_storage
+      filename = acc.image_file.original_filename
+      content_type = Marcel::MimeType.for(extension: File.extname(filename))
+                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/MethodCallWithArgsParentheses: Omit parentheses for method calls with arguments.
+      picture.image_file = filename
+    end
+  end
+end

--- a/tests/fixtures/cops/style/method_call_with_args_parentheses/offense.rb
+++ b/tests/fixtures/cops/style/method_call_with_args_parentheses/offense.rb
@@ -222,3 +222,26 @@ end
 # Interpolated x-strings are not macro wrappers.
 %x{#{raise TypeError, "x"}}
      ^^^^^^^^^^^^^^^^^^^^ Style/MethodCallWithArgsParentheses: Use parentheses for method calls with arguments.
+
+# A pure `begin ... end` whose parent is a setter assignment must NOT propagate
+# macro scope. RuboCop's in_macro_scope? rejects the surrounding setter as a
+# wrapper, so receiverless calls in the begin's `if`/`else` branches still flag.
+Foo.bar.baz = begin
+  if (token = ENV.fetch('SECRET_KEY_BASE', nil)).present?
+    token
+  elsif Rails.env.production?
+    raise 'You must set SECRET_KEY_BASE'
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/MethodCallWithArgsParentheses: Use parentheses for method calls with arguments.
+  else
+    sf = Rails.root.join('tmp/secret_key_base')
+    if File.exist?(sf)
+      File.read(sf)
+    else
+      puts "=> Generating initial SECRET_KEY_BASE in #{sf}"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Style/MethodCallWithArgsParentheses: Use parentheses for method calls with arguments.
+      token = SecureRandom.hex(30)
+      File.write(sf, token)
+      token
+    end
+  end
+end


### PR DESCRIPTION
Four narrower divergences against the latest oracle (default 0 FP / 2 FN
and omit_parentheses 458 FP / 8,423 FN):

1. Default-config FN regression in visit_begin_node. The 5fab6cc fix that
   pops an outer Call/CallAssignedRhs/Super at begin entry also caused
   nested_in_non_wrapper() to read the parent_stack with the leaked parent
   already gone. For `Foo.config.x = begin ...; raise "msg"; ...; end`,
   the begin's wrapper-vs-non-wrapper decision lost the surrounding
   setter, so the inner `raise`/`puts` were silently treated as macros.
   Capture nested_in_non_wrapper() BEFORE popping leaked_parent.

2. omit_parentheses FP on ternary `else` branches whose body is an
   assignment with a parenthesized RHS call. RuboCop's
   `assignment_in_condition?` allows parens because the surrounding
   ternary `if` is `conditional?`. nitrocop only matched
   Conditional/ConditionalBody/When/WhenBody as the grandparent, missing
   TernaryBranch. Added TernaryBranch to the grandparent match.

3. omit_parentheses FN on multi-statement when/if/else bodies whose
   inner assignment leaked the OUTER if/case ConditionalBody/WhenBody as
   grandparent. Parser AST wraps multi-statement bodies in a synthetic
   `:begin`, so RuboCop's grandparent of an inner lvasgn is the begin
   (not conditional/when). Added a synthetic ParentKind::Begin boundary
   marker pushed for multi-statement bodies in both
   visit_statements_node and visit_statements_with_parent. Added Begin
   to nested_in_non_wrapper's exempt list because :begin/:kwbegin ARE
   wrappers in in_macro_scope?.

4. omit_parentheses FN on hash-value-omission calls inside a block body
   whose outer enclosing expression is non-last. RuboCop's
   last_expression? only inspects the call's own (or assignment parent's)
   right sibling, so it restarts inside each block. nitrocop's depth
   counter only reset at def entry, leaking outer non-last positions
   into block bodies. Reset non_last_expression_depth at every
   block/lambda body entry (matching the def reset).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>