### PR TITLE
Fix Style/RedundantParentheses fuzz crash on missing-receiver unary

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -466,7 +466,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nitrocop"
-version = "0.0.1-pre5"
+version = "0.0.1-pre12"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/cop/style/redundant_parentheses.rs
+++ b/src/cop/style/redundant_parentheses.rs
@@ -2098,7 +2098,15 @@ fn is_spaced_unary_plus_minus_call(content: &[u8], call: &ruby_prism::CallNode<'
         return false;
     };
 
-    let between = &content[message_loc.end_offset()..receiver.location().start_offset()];
+    // Parse-error recovery can produce a synthetic receiver (e.g. `MissingNode`)
+    // whose location overlaps the message — guard against an inverted range.
+    let start = message_loc.end_offset();
+    let end = receiver.location().start_offset();
+    if start > end || end > content.len() {
+        return false;
+    }
+
+    let between = &content[start..end];
     between
         .iter()
         .any(|b| matches!(b, b' ' | b'\t' | b'\n' | b'\r'))


### PR DESCRIPTION
## Summary
- Follow-up to #2374 — fixes the actual panic reproduced by `fuzz/seeds/fuzz_all_cops/crash-4f902e46c064638a6783a11f7ef1b8b7663314ad`.
- `is_spaced_unary_plus_minus_call` sliced `content[message_loc.end..receiver.location().start]`. When Prism recovers from a parse error by giving a `-@` `CallNode` a synthetic `MissingNode` receiver at the same location as the `-` message, the slice becomes inverted (`[2..1]`) and panics. Guarded against the inverted/out-of-range case so parse-recovery shapes are treated as not spaced.

## Test plan
- [x] `cargo +nightly fuzz run fuzz_all_cops fuzz/seeds/fuzz_all_cops/ -- -runs=1` — all 4 seeds pass
- [x] `cargo test --lib --release -- cop::style::redundant_parentheses` — 3/3 pass
- [x] `cargo fmt` + `cargo clippy --release -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)