### PR TITLE
Fix three regressions in MethodCallWithArgsParentheses cop

### DIFF
--- a/src/cop/style/method_call_with_args_parentheses.rs
+++ b/src/cop/style/method_call_with_args_parentheses.rs
@@ -2414,9 +2414,14 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
 
         self.push_macro_scope(MacroScope::NotMacroScope);
 
-        // Visit the predicate.
+        // The case predicate's Parser parent is the `case` node, which is
+        // `conditional?`. Push `Conditional` so `assignment_in_condition?`
+        // matches for an inline assignment in the predicate
+        // (`case response = http.request(...)`).
         if let Some(predicate) = node.predicate() {
+            self.push_parent(ParentKind::Conditional);
             self.visit(&predicate);
+            self.pop_parent();
         }
 
         // Visit when conditions/bodies via their existing visit_when_node.
@@ -2457,7 +2462,26 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
         };
 
         self.push_macro_scope(MacroScope::NotMacroScope);
-        ruby_prism::visit_case_match_node(self, node);
+
+        // Mirror visit_case_node: the case_match predicate's Parser parent is
+        // `case_match` (`conditional?`); the else clause body has `case_match`
+        // as direct parent too.
+        if let Some(predicate) = node.predicate() {
+            self.push_parent(ParentKind::Conditional);
+            self.visit(&predicate);
+            self.pop_parent();
+        }
+
+        for cond in node.conditions().iter() {
+            self.visit(&cond);
+        }
+
+        if let Some(else_clause) = node.else_clause() {
+            if let Some(stmts) = else_clause.statements() {
+                self.visit_statements_with_parent(&stmts, ParentKind::ConditionalBody);
+            }
+        }
+
         self.pop_scope();
 
         if let Some(parent) = leaked_parent {

--- a/src/cop/style/method_call_with_args_parentheses.rs
+++ b/src/cop/style/method_call_with_args_parentheses.rs
@@ -486,6 +486,40 @@ use crate::parse::source::SourceFile;
 /// and `visit_statements_with_parent` via `_loc` variants that accept an
 /// `Option<(usize, usize)>` location for the synthetic `CallLikeBlockBody`
 /// boundary.
+///
+/// ## Variant fix (2026-04-27, oracle: 385 FP / 2,384 FN)
+///
+/// Three independent regressions remained on the latest oracle:
+///
+/// 1. **`hash_literal_in_arguments?` missed hashes hidden behind non-send
+///    descendants.** RuboCop runs `node.descendants.any? { hash_literal? }`
+///    over the WHOLE call subtree once any direct argument is a send. The
+///    hand-rolled `has_hash_literal` only recursed through call args/recv,
+///    array elements, and hash pairs, so a `{}` reachable through an
+///    `||=` op-asgn arg (`create_ou_tree(ou, hous[k] ||= {}, ...)`) or
+///    through an `lvasgn = {...}` arg (`described_class.new(values = {...},
+///    admin)`) was invisible. Replaced with a Prism `Visit` traversal that
+///    matches `descendants.any?` exactly.
+///
+/// 2. **`and`/`or` keyword operators were treated as `logical_operator?`.**
+///    `PredicateOperatorNode#logical_operator?` in rubocop-ast returns true
+///    only when the operator source is `&&` or `||` — `and`/`or` keywords
+///    are "semantic" operators and are NOT `logical_operator?`. Calls under
+///    `and`/`or` parents must therefore still flag because
+///    `call_in_logical_operators?` returns false. nitrocop pushed
+///    `ParentKind::LogicalOp` for ALL And/Or nodes, exempting these calls.
+///    Now `visit_and_node`/`visit_or_node` consult `operator_loc()` and
+///    only push `LogicalOp` for `&&` / `||`. The `is_ambiguous_node`
+///    descendant predicate also checks operator slice for the same reason.
+///
+/// 3. **`case ... else <call> end` lost its conditional grandparent.**
+///    Default Prism traversal of the else clause did not push any
+///    parent context, so an inner `lvasgn = call(...)` saw the surrounding
+///    `def`/`if` body as its grandparent and `assignment_in_condition?`
+///    returned false. Override `visit_case_node` to dispatch the else
+///    statements through `visit_statements_with_parent(stmts,
+///    ConditionalBody)` so the assignment grandparent matches RuboCop's
+///    `case` (which is `conditional?`).
 pub struct MethodCallWithArgsParentheses;
 
 /// Check if a method name matches any pattern in the list (regex-style).
@@ -1490,70 +1524,53 @@ fn unwrap_parenthesized_node<'a>(node: &ruby_prism::Node<'a>) -> Option<ruby_pri
     }
 }
 
-/// Check if a node contains a hash literal with braces (not keyword hash)
-fn has_hash_literal(node: &ruby_prism::Node<'_>) -> bool {
-    if let Some(unwrapped) = unwrap_parenthesized_node(node) {
-        return has_hash_literal(&unwrapped);
-    }
+/// Returns true when the operator slice is `&&` or `||` (the "logical"
+/// operators in rubocop-ast's `PredicateOperatorNode#logical_operator?`).
+/// `and`/`or` keywords return false — they are "semantic" operators and do
+/// not satisfy `logical_operator?`.
+fn is_short_circuit_operator(op: &[u8]) -> bool {
+    op == b"&&" || op == b"||"
+}
 
-    if let Some(hash) = node.as_hash_node() {
-        if hash.opening_loc().as_slice() == b"{" {
+fn call_contains_hash_literal(call: &ruby_prism::CallNode<'_>) -> bool {
+    let mut visitor = HashLiteralDescendantVisitor { found: false };
+    if let Some(recv) = call.receiver() {
+        visitor.visit(&recv);
+        if visitor.found {
             return true;
         }
     }
-    // Recurse into descendants
-    if let Some(call) = node.as_call_node() {
-        if let Some(args) = call.arguments() {
-            for arg in args.arguments().iter() {
-                if has_hash_literal(&arg) {
-                    return true;
-                }
-            }
-        }
-        if let Some(recv) = call.receiver() {
-            if has_hash_literal(&recv) {
+    if let Some(args) = call.arguments() {
+        for arg in args.arguments().iter() {
+            visitor.visit(&arg);
+            if visitor.found {
                 return true;
             }
-        }
-    }
-    if let Some(array) = node.as_array_node() {
-        for elem in array.elements().iter() {
-            if has_hash_literal(&elem) {
-                return true;
-            }
-        }
-    }
-    if let Some(kw_hash) = node.as_keyword_hash_node() {
-        for elem in kw_hash.elements().iter() {
-            if has_hash_literal(&elem) {
-                return true;
-            }
-        }
-    }
-    if let Some(assoc) = node.as_assoc_node() {
-        if has_hash_literal(&assoc.value()) {
-            return true;
         }
     }
     false
 }
 
-fn call_contains_hash_literal(call: &ruby_prism::CallNode<'_>) -> bool {
-    if let Some(recv) = call.receiver() {
-        if has_hash_literal(&recv) {
-            return true;
-        }
-    }
+/// Visit-based traversal that finds any braced hash literal descendant.
+/// Mirrors rubocop-ast's `node.descendants.any? { |d| d.hash_type? && d.braces? }`.
+/// The hand-rolled `has_hash_literal` only recursed into a few specific node
+/// shapes (call args/recv, array elements, hash pairs) so it missed `{}`
+/// hidden inside op-asgn/lvasgn/begin/etc. children.
+struct HashLiteralDescendantVisitor {
+    found: bool,
+}
 
-    if let Some(args) = call.arguments() {
-        for arg in args.arguments().iter() {
-            if has_hash_literal(&arg) {
-                return true;
+impl<'pr> Visit<'pr> for HashLiteralDescendantVisitor {
+    fn visit_branch_node_enter(&mut self, node: ruby_prism::Node<'pr>) {
+        if self.found {
+            return;
+        }
+        if let Some(hash) = node.as_hash_node() {
+            if hash.opening_loc().as_slice() == b"{" {
+                self.found = true;
             }
         }
     }
-
-    false
 }
 
 /// Check if a CallNode has parenthesized ancestor calls in the chain
@@ -1604,10 +1621,22 @@ fn is_ambiguous_node(node: &ruby_prism::Node<'_>, source: &SourceFile) -> bool {
         || node.as_lambda_node().is_some()
         || node.as_block_node().is_some()
         || node.as_forwarding_arguments_node().is_some()
-        || node.as_and_node().is_some()
-        || node.as_or_node().is_some()
     {
         return true;
+    }
+
+    // RuboCop's `logical_operator?` only returns true when the operator source
+    // is `&&` or `||` — `and`/`or` keywords are "semantic" operators and are
+    // NOT treated as ambiguous by `call_with_ambiguous_arguments?`.
+    if let Some(and) = node.as_and_node() {
+        if is_short_circuit_operator(and.operator_loc().as_slice()) {
+            return true;
+        }
+    }
+    if let Some(or) = node.as_or_node() {
+        if is_short_circuit_operator(or.operator_loc().as_slice()) {
+            return true;
+        }
     }
 
     // Ternary if — has then_keyword (the `?`) but no end_keyword
@@ -2305,17 +2334,30 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
     }
 
     fn visit_and_node(&mut self, node: &ruby_prism::AndNode<'pr>) {
-        self.push_parent(ParentKind::LogicalOp);
+        // RuboCop's `logical_operator?` returns true only for `&&` / `||`.
+        // `and`/`or` keywords are "semantic" operators and DO NOT satisfy
+        // `call_in_logical_operators?`, so calls under them must still flag.
+        let push_parent = is_short_circuit_operator(node.operator_loc().as_slice());
+        if push_parent {
+            self.push_parent(ParentKind::LogicalOp);
+        }
         self.visit(&node.left());
         self.visit(&node.right());
-        self.pop_parent();
+        if push_parent {
+            self.pop_parent();
+        }
     }
 
     fn visit_or_node(&mut self, node: &ruby_prism::OrNode<'pr>) {
-        self.push_parent(ParentKind::LogicalOp);
+        let push_parent = is_short_circuit_operator(node.operator_loc().as_slice());
+        if push_parent {
+            self.push_parent(ParentKind::LogicalOp);
+        }
         self.visit(&node.left());
         self.visit(&node.right());
-        self.pop_parent();
+        if push_parent {
+            self.pop_parent();
+        }
     }
 
     fn visit_optional_parameter_node(&mut self, node: &ruby_prism::OptionalParameterNode<'pr>) {
@@ -2371,7 +2413,26 @@ impl<'pr> Visit<'pr> for ParenVisitor<'_> {
         };
 
         self.push_macro_scope(MacroScope::NotMacroScope);
-        ruby_prism::visit_case_node(self, node);
+
+        // Visit the predicate.
+        if let Some(predicate) = node.predicate() {
+            self.visit(&predicate);
+        }
+
+        // Visit when conditions/bodies via their existing visit_when_node.
+        for cond in node.conditions().iter() {
+            self.visit(&cond);
+        }
+
+        // The `else` branch's body has the `case` node as its Parser parent,
+        // which is `conditional?`. Push `ConditionalBody` for the body so
+        // `assignment_in_condition?` matches for inner assignment RHS calls.
+        if let Some(else_clause) = node.else_clause() {
+            if let Some(stmts) = else_clause.statements() {
+                self.visit_statements_with_parent(&stmts, ParentKind::ConditionalBody);
+            }
+        }
+
         self.pop_scope();
 
         if let Some(parent) = leaked_parent {

--- a/tests/fixtures/cops/style/method_call_with_args_parentheses/no_offense.omit_parentheses.rb
+++ b/tests/fixtures/cops/style/method_call_with_args_parentheses/no_offense.omit_parentheses.rb
@@ -98,3 +98,30 @@ def points_creator
             .compact
             .map { |location| location.merge(user_id:) }
 end
+
+# Hash literal reachable through a non-send/non-hash descendant of an arg.
+# RuboCop's `hash_literal_in_arguments?` runs `node.descendants.any?` over the
+# whole subtree once a direct arg is a send call, so a `{}` nested inside an
+# `||=` op-asgn arg or an `lvasgn = {...}` arg keeps the parens too.
+def allowed_ous_tree_each
+  ous = {}
+  hous = {}
+  ous.each { |ou| create_ou_tree(ou, hous[dc_path] ||= {}, ou[0].split(',')) }
+end
+
+def workflow_setup
+  workflow = described_class.new(values = {:running_pre_dialog => false}, admin)
+end
+
+# Single-statement `else` body of a `case` expression. RuboCop's
+# `assignment_in_condition?` exempts because the lvasgn's grandparent is the
+# `case` node (`conditional?`). nitrocop must push `ConditionalBody` for the
+# else branch's single statement so that grandparent matches.
+def format_timezone_else(new_time)
+  case ftype
+  when "tl"
+    new_time = I18n.l(new_time)
+  else
+    new_time = I18n.l(new_time)
+  end
+end

--- a/tests/fixtures/cops/style/method_call_with_args_parentheses/no_offense.omit_parentheses.rb
+++ b/tests/fixtures/cops/style/method_call_with_args_parentheses/no_offense.omit_parentheses.rb
@@ -125,3 +125,14 @@ def format_timezone_else(new_time)
     new_time = I18n.l(new_time)
   end
 end
+
+# Inline assignment as the case predicate keeps parens because the lvasgn's
+# Parser parent is the `case` node (`conditional?`).
+def fetch_with_redirect(http, request)
+  begin
+    case response = http.request(request)
+    when Net::HTTPRedirection then location = response['location']
+    when Net::HTTPClientError, Net::HTTPServerError then response.error!
+    end
+  end until Net::HTTPSuccess == response
+end

--- a/tests/fixtures/cops/style/method_call_with_args_parentheses/offense.omit_parentheses.rb
+++ b/tests/fixtures/cops/style/method_call_with_args_parentheses/offense.omit_parentheses.rb
@@ -122,3 +122,35 @@ def picture_factory(picture, acc)
     end
   end
 end
+
+# `and` / `or` keyword operators are NOT logical_operator? in rubocop-ast
+# (only `&&` and `||` are). Calls under an `and`/`or` parent must therefore
+# still flag because `call_in_logical_operators?` returns false. nitrocop
+# previously treated all AndNode/OrNode parents as logical, exempting these.
+def textual?(object)
+  object.is_a?(Symbol) or object.is_a?(String)
+              ^^^^^^^^ Style/MethodCallWithArgsParentheses: Omit parentheses for method calls with arguments.
+                                      ^^^^^^^^ Style/MethodCallWithArgsParentheses: Omit parentheses for method calls with arguments.
+end
+
+def can_interpret?(parent, keyword, *args, &block)
+  (
+    keyword == 'bind' and
+      (
+        (
+          (args.size == 1)
+        ) ||
+        (
+          (args.size == 2) and
+            textual?(args[1])
+                    ^^^^^^^^^ Style/MethodCallWithArgsParentheses: Omit parentheses for method calls with arguments.
+        )
+      )
+  )
+end
+
+# `&&` / `||` STILL exempt their operands via `call_in_logical_operators?`.
+# Sanity check that semantic-vs-logical distinction does not over-fire.
+def textual_and?(object)
+  object.is_a?(Symbol) && object.is_a?(String)
+end


### PR DESCRIPTION
## Summary

This PR fixes three independent regressions in the `MethodCallWithArgsParentheses` cop that were causing false positives (385 FP) and false negatives (2,384 FN) on the latest oracle test suite.

## Key Changes

1. **Replace hand-rolled hash literal detection with visitor-based traversal**
   - The previous `has_hash_literal()` function only recursed through specific node types (call args/recv, array elements, hash pairs), missing hash literals hidden inside op-asgn, lvasgn, begin, and other node types
   - Implemented `HashLiteralDescendantVisitor` using Prism's `Visit` trait to match RuboCop's `node.descendants.any? { hash_literal? }` behavior exactly
   - This fixes cases like `create_ou_tree(ou, hous[k] ||= {}, ...)` and `described_class.new(values = {...}, admin)`

2. **Distinguish between logical (`&&`/`||`) and semantic (`and`/`or`) operators**
   - RuboCop's `PredicateOperatorNode#logical_operator?` returns true only for `&&` and `||` operators, not for `and`/`or` keywords
   - Added `is_short_circuit_operator()` helper to check operator slice
   - Updated `visit_and_node()` and `visit_or_node()` to only push `LogicalOp` parent context for `&&`/`||`, allowing calls under `and`/`or` to properly flag
   - Updated `is_ambiguous_node()` to apply the same distinction

3. **Fix case/case-match else clause parent context**
   - Default Prism traversal of case else clauses did not push conditional parent context, causing `assignment_in_condition?` to fail for assignments in else bodies
   - Overrode `visit_case_node()` and `visit_case_match_node()` to:
     - Push `Conditional` parent for the case predicate
     - Push `ConditionalBody` parent for else clause statements via `visit_statements_with_parent()`
   - This ensures inline assignments like `case response = http.request(...)` are properly recognized as conditional assignments

## Test Coverage

Added test cases covering:
- Hash literals in op-asgn and lvasgn arguments
- `and`/`or` keyword operators (should flag) vs `&&`/`||` (should not flag)
- Case expression else clauses with assignments
- Case predicate with inline assignments

https://claude.ai/code/session_017Mn9SwqDftog1fA6TJaBUH