### PR TITLE
Fix variable liveness tracking for assignments and nested targets

### DIFF
--- a/src/cop/lint/useless_assignment.rs
+++ b/src/cop/lint/useless_assignment.rs
@@ -896,13 +896,17 @@ fn candidate_has_reference_after(candidate: &AssignmentCandidate, offset: usize)
 //
 // RuboCop's `process_rescue` treats a `begin ... rescue ... end` containing
 // `retry` as a loop, which (combined with the variable_force walk) keeps any
-// `rescue X => e` capture of the same name alive across the entire surrounding
-// scope — even captures in other begin blocks that don't themselves use `e`.
+// `rescue X => e` capture of the same name alive in *sibling* begin blocks —
+// e.g. an `if/else` whose two branches both have a rescue capturing `e` and
+// only one of which actually reads `e` and retries.
 //
-// Mirror that quirk: when one `rescue X => name` clause in a scope (def/class/
-// module/lambda or top-level) contains both `retry` and a read of `name`,
-// suppress the unused-warning for every rescue capture of that name in the
-// same scope.
+// The protection does **not** extend into begin blocks that contain the
+// retrying begin (e.g. `def f; begin; do_something do; begin; ...; rescue =>
+// e; ...; retry; end; end; rescue Timeout::Error => e; end; end` — the outer
+// `Timeout::Error => e` is independent of the inner retry). Mirror that by
+// tracking each retry-protected begin's full range and only suppressing
+// rescue captures whose enclosing begin does **not** contain the retrying
+// begin.
 
 fn collect_retry_protected_rescue_capture_offsets(
     parse_result: &ruby_prism::ParseResult<'_>,
@@ -911,21 +915,38 @@ fn collect_retry_protected_rescue_capture_offsets(
     collector.visit(&parse_result.node());
     let mut suppress_collector = RetryProtectedSuppressCollector {
         protected: &collector.protected,
-        scope_stack: vec![0],
+        begin_stack: Vec::new(),
+        scope_stack: Vec::new(),
         offsets: HashSet::new(),
     };
     suppress_collector.visit(&parse_result.node());
     suppress_collector.offsets
 }
 
+/// (scope_offset, variable_name) keying retry-protection.
+type RetryProtectedKey = (usize, Vec<u8>);
+/// (begin_start_offset, begin_end_offset).
+type BeginRange = (usize, usize);
+/// Map keyed by (scope_offset, variable_name) → list of begin ranges inside
+/// that scope whose rescue chain has retry-and-read of the variable.
+type RetryProtectedMap = HashMap<RetryProtectedKey, Vec<BeginRange>>;
+
 #[derive(Default)]
 struct RetryProtectedRescueCollector {
-    /// (scope_offset, name) pairs where a rescue clause uses `name` and contains retry.
-    protected: HashSet<(usize, Vec<u8>)>,
+    /// `(scope_offset, name)` → list of `(begin_start, begin_end)` ranges of
+    /// `begin` blocks inside that scope whose rescue chain contains `retry`
+    /// and a read of `name`. Suppression is scope-local: a retry-rescue in
+    /// a different def does not protect captures in this def.
+    protected: RetryProtectedMap,
+    begin_stack: Vec<BeginRange>,
     scope_stack: Vec<usize>,
 }
 
 impl RetryProtectedRescueCollector {
+    fn current_begin(&self) -> Option<(usize, usize)> {
+        self.begin_stack.last().copied()
+    }
+
     fn current_scope(&self) -> usize {
         self.scope_stack.last().copied().unwrap_or(0)
     }
@@ -1008,10 +1029,23 @@ impl<'pr> Visit<'pr> for RetryProtectedRescueCollector {
         self.enter_scope(offset, |this| ruby_prism::visit_lambda_node(this, node));
     }
 
+    fn visit_begin_node(&mut self, node: &ruby_prism::BeginNode<'pr>) {
+        let loc = node.location();
+        self.begin_stack
+            .push((loc.start_offset(), loc.end_offset()));
+        ruby_prism::visit_begin_node(self, node);
+        self.begin_stack.pop();
+    }
+
     fn visit_rescue_node(&mut self, node: &ruby_prism::RescueNode<'pr>) {
         if let Some(name) = rescue_clause_capture_name(node) {
             if rescue_clause_body_has_retry_and_read(node, &name) {
-                self.protected.insert((self.current_scope(), name));
+                if let Some(begin) = self.current_begin() {
+                    self.protected
+                        .entry((self.current_scope(), name))
+                        .or_default()
+                        .push(begin);
+                }
             }
         }
         ruby_prism::visit_rescue_node(self, node);
@@ -1019,12 +1053,17 @@ impl<'pr> Visit<'pr> for RetryProtectedRescueCollector {
 }
 
 struct RetryProtectedSuppressCollector<'a> {
-    protected: &'a HashSet<(usize, Vec<u8>)>,
+    protected: &'a RetryProtectedMap,
+    begin_stack: Vec<BeginRange>,
     scope_stack: Vec<usize>,
     offsets: HashSet<usize>,
 }
 
 impl<'a> RetryProtectedSuppressCollector<'a> {
+    fn current_begin(&self) -> Option<(usize, usize)> {
+        self.begin_stack.last().copied()
+    }
+
     fn current_scope(&self) -> usize {
         self.scope_stack.last().copied().unwrap_or(0)
     }
@@ -1057,11 +1096,34 @@ impl<'pr> Visit<'pr> for RetryProtectedSuppressCollector<'_> {
         self.enter_scope(offset, |this| ruby_prism::visit_lambda_node(this, node));
     }
 
+    fn visit_begin_node(&mut self, node: &ruby_prism::BeginNode<'pr>) {
+        let loc = node.location();
+        self.begin_stack
+            .push((loc.start_offset(), loc.end_offset()));
+        ruby_prism::visit_begin_node(self, node);
+        self.begin_stack.pop();
+    }
+
     fn visit_rescue_node(&mut self, node: &ruby_prism::RescueNode<'pr>) {
         if let Some(name) = rescue_clause_capture_name(node) {
-            if self.protected.contains(&(self.current_scope(), name)) {
-                if let Some(offset) = rescue_clause_capture_offset(node) {
-                    self.offsets.insert(offset);
+            if let (Some((b_start, b_end)), Some(ranges)) = (
+                self.current_begin(),
+                self.protected.get(&(self.current_scope(), name)),
+            ) {
+                let protected = ranges.iter().any(|&(p_start, p_end)| {
+                    // Self-protection: same begin block.
+                    (p_start == b_start && p_end == b_end)
+                        // Sibling/unrelated: protecting begin is *outside* the
+                        // current begin (not nested inside it). RuboCop keeps
+                        // a sibling retry-rescue's captures alive but not those
+                        // in an outer begin that *contains* the retrying begin.
+                        || p_start < b_start
+                        || p_end > b_end
+                });
+                if protected {
+                    if let Some(offset) = rescue_clause_capture_offset(node) {
+                        self.offsets.insert(offset);
+                    }
                 }
             }
         }

--- a/src/cop/lint/useless_assignment.rs
+++ b/src/cop/lint/useless_assignment.rs
@@ -170,17 +170,30 @@ impl Cop for UselessAssignment {
         let mut rescue_modifier_collector = RescueModifierWriteCollector::default();
         rescue_modifier_collector.visit(&parse_result.node());
         let rescue_modifier_writes = rescue_modifier_collector.writes;
+        let chained_assignment_descendants =
+            collect_chained_assignment_descendant_offsets(parse_result);
         let mut candidates = collector.take_candidates();
         candidates.sort_by_key(|candidate| candidate.node_offset);
+        let mut suppressed_chained_descendants: HashSet<usize> = HashSet::new();
 
         for candidate in candidates {
             if pattern_match_offsets.contains(&candidate.node_offset) {
                 continue;
             }
 
-            let emit = if conditional_operator_offsets.contains(&candidate.node_offset) {
+            if suppressed_chained_descendants.contains(&candidate.node_offset) {
+                continue;
+            }
+
+            let emit = if candidate.captured_protection {
+                false
+            } else if !candidate.engine_used
+                && conditional_operator_offsets.contains(&candidate.node_offset)
+            {
                 true
-            } else if !candidate.engine_used {
+            } else if candidate.engine_used {
+                false
+            } else {
                 !should_suppress_multi_rescue_false_positive(&candidate, &rescue_contexts)
                     && !or_condition_offsets.contains(&candidate.node_offset)
                     && !post_condition_loop_body_offsets.contains(&candidate.node_offset)
@@ -189,12 +202,14 @@ impl Cop for UselessAssignment {
                         &rescue_modifier_writes,
                     )
                     && !retry_protected_rescue_offsets.contains(&candidate.node_offset)
-            } else {
-                false
             };
 
             if !emit {
                 continue;
+            }
+
+            if let Some(descendants) = chained_assignment_descendants.get(&candidate.node_offset) {
+                suppressed_chained_descendants.extend(descendants);
             }
 
             let (line, column) = source.offset_to_line_col(candidate.node_offset);
@@ -229,6 +244,12 @@ struct AssignmentCandidate {
     node_offset: usize,
     branch_id: Option<usize>,
     engine_used: bool,
+    /// Whether the assignment's value flows out via a block capture rather
+    /// than a real reference. Used to suppress force-emit pathways
+    /// (e.g. the `cond ? var += ... : var` operator collector) that mirror
+    /// RuboCop's flagging — RuboCop honours `captured_by_block` via
+    /// `Assignment#used?`, so capture-only liveness should also win there.
+    captured_protection: bool,
     value_range: Option<(usize, usize)>,
     assignment_states: Vec<AssignmentState>,
     reference_states: Vec<ReferenceState>,
@@ -278,11 +299,14 @@ impl variable_force::VariableForceConsumer for PendingOffenseCollector {
                 })
                 .collect();
             for assignment in &variable.assignments {
+                let captured_protection =
+                    !assignment.referenced && variable.captured_by_block && !assignment.reassigned;
                 candidates.push(AssignmentCandidate {
                     name: variable.name.clone(),
                     node_offset: assignment.node_offset,
                     branch_id: assignment.branch_id,
                     engine_used: assignment.used(variable.captured_by_block),
+                    captured_protection,
                     value_range: assignment.value_range,
                     assignment_states: assignment_states.clone(),
                     reference_states: reference_states.clone(),
@@ -1042,6 +1066,59 @@ impl<'pr> Visit<'pr> for RetryProtectedSuppressCollector<'_> {
             }
         }
         ruby_prism::visit_rescue_node(self, node);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FP suppression: chained assignment (`outer = method(... inner = value ...)`).
+// ---------------------------------------------------------------------------
+//
+// RuboCop's `Lint/UselessAssignment` calls `ignore_node` on chained assignment
+// nodes whose RHS is a send after reporting the outer offense. Subsequent
+// reverse-iteration over assignments to the *inner* variable then sees the
+// inner write as `part_of_ignored_node?` and skips it.
+//
+// We approximate that with a narrower targeted rule: only suppress lvasgn
+// nodes that appear as **direct positional arguments** of the outer call,
+// i.e. patterns like `resolve(records, properties, name = value)` where the
+// inline assignment is functioning as a self-documenting positional argument.
+// This handles the archivesspace case while keeping the suppression scope
+// tight enough that Prism's tolerant parsing of malformed source can not
+// silently swallow unrelated later statements.
+
+fn collect_chained_assignment_descendant_offsets(
+    parse_result: &ruby_prism::ParseResult<'_>,
+) -> HashMap<usize, HashSet<usize>> {
+    let mut collector = ChainedAssignmentDescendantCollector::default();
+    collector.visit(&parse_result.node());
+    collector.descendants
+}
+
+#[derive(Default)]
+struct ChainedAssignmentDescendantCollector {
+    descendants: HashMap<usize, HashSet<usize>>,
+}
+
+impl<'pr> Visit<'pr> for ChainedAssignmentDescendantCollector {
+    fn visit_local_variable_write_node(&mut self, node: &ruby_prism::LocalVariableWriteNode<'pr>) {
+        let outer_offset = node.location().start_offset();
+        let value = node.value();
+        if let Some(call) = value.as_call_node() {
+            if call.closing_loc().is_some() {
+                if let Some(args) = call.arguments() {
+                    let mut descendants: HashSet<usize> = HashSet::new();
+                    for arg in args.arguments().iter() {
+                        if let Some(inner) = arg.as_local_variable_write_node() {
+                            descendants.insert(inner.location().start_offset());
+                        }
+                    }
+                    if !descendants.is_empty() {
+                        self.descendants.insert(outer_offset, descendants);
+                    }
+                }
+            }
+        }
+        ruby_prism::visit_local_variable_write_node(self, node);
     }
 }
 

--- a/src/cop/variable_force/engine.rs
+++ b/src/cop/variable_force/engine.rs
@@ -544,6 +544,80 @@ impl<'a> Engine<'a> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn assign_multi_target(
+        &mut self,
+        target: &ruby_prism::Node<'_>,
+        rhs_refs: &[(Vec<u8>, bool)],
+        in_branch: bool,
+        shadowing_in_branch: bool,
+        branch_id: Option<usize>,
+        branch_path: Vec<usize>,
+        seq: usize,
+    ) {
+        if let Some(t) = target.as_local_variable_target_node() {
+            let name = t.name().as_slice().to_vec();
+            let offset = t.location().start_offset();
+            if !self.table.variable_exists(&name) {
+                self.declare_variable(name.clone(), offset, DeclarationKind::Assignment);
+            }
+            let rhs_refs_var = rhs_refs
+                .iter()
+                .find(|(n, _)| n == &name)
+                .is_some_and(|(_, r)| *r);
+            let mut a = Assignment::new(offset, AssignmentKind::Multiple);
+            a.in_branch = in_branch;
+            a.shadowing_in_branch = shadowing_in_branch;
+            a.branch_id = branch_id;
+            a.branch_path = branch_path;
+            a.sequence = seq;
+            a.rhs_references_var = rhs_refs_var;
+            self.table.assign_to_variable(&name, a);
+        } else if let Some(mt) = target.as_multi_target_node() {
+            // Nested parenthesized targets: `(a,), b = []`. Recurse into each
+            // inner target so nested local-variable targets get assignments.
+            for inner in mt.lefts().iter() {
+                self.assign_multi_target(
+                    &inner,
+                    rhs_refs,
+                    in_branch,
+                    shadowing_in_branch,
+                    branch_id,
+                    branch_path.clone(),
+                    seq,
+                );
+            }
+            if let Some(rest) = mt.rest() {
+                if let Some(splat) = rest.as_splat_node() {
+                    if let Some(expr) = splat.expression() {
+                        self.assign_multi_target(
+                            &expr,
+                            rhs_refs,
+                            in_branch,
+                            shadowing_in_branch,
+                            branch_id,
+                            branch_path.clone(),
+                            seq,
+                        );
+                    }
+                }
+            }
+            for inner in mt.rights().iter() {
+                self.assign_multi_target(
+                    &inner,
+                    rhs_refs,
+                    in_branch,
+                    shadowing_in_branch,
+                    branch_id,
+                    branch_path.clone(),
+                    seq,
+                );
+            }
+        } else {
+            self.visit(target);
+        }
+    }
+
     fn declare_and_assign_for_targets(&mut self, node: &ruby_prism::Node<'_>) {
         struct TargetCollector {
             targets: Vec<(Vec<u8>, usize)>,
@@ -1011,12 +1085,12 @@ impl<'pr> Visit<'pr> for Engine<'_> {
     }
 
     fn visit_multi_write_node(&mut self, node: &ruby_prism::MultiWriteNode<'pr>) {
-        // Collect target names before visiting the RHS so we can detect self-refs
+        // Collect target names (including inside nested parenthesized targets
+        // like `(a,), b = []`) before visiting the RHS so we can detect
+        // self-references.
         let mut target_names: Vec<Vec<u8>> = Vec::new();
         for target in node.lefts().iter() {
-            if let Some(t) = target.as_local_variable_target_node() {
-                target_names.push(t.name().as_slice().to_vec());
-            }
+            collect_multi_target_lvar_names(&target, &mut target_names);
         }
         if let Some(rest) = node.rest() {
             if let Some(splat) = rest.as_splat_node() {
@@ -1028,9 +1102,7 @@ impl<'pr> Visit<'pr> for Engine<'_> {
             }
         }
         for target in node.rights().iter() {
-            if let Some(t) = target.as_local_variable_target_node() {
-                target_names.push(t.name().as_slice().to_vec());
-            }
+            collect_multi_target_lvar_names(&target, &mut target_names);
         }
 
         // Bare `super` (ForwardingSuperNode) implicitly forwards all method
@@ -1080,27 +1152,15 @@ impl<'pr> Visit<'pr> for Engine<'_> {
         let seq = self.next_sequence();
 
         for target in node.lefts().iter() {
-            if let Some(t) = target.as_local_variable_target_node() {
-                let name = t.name().as_slice().to_vec();
-                let offset = t.location().start_offset();
-                if !self.table.variable_exists(&name) {
-                    self.declare_variable(name.clone(), offset, DeclarationKind::Assignment);
-                }
-                let rhs_refs_var = rhs_refs
-                    .iter()
-                    .find(|(n, _)| n == &name)
-                    .is_some_and(|(_, r)| *r);
-                let mut a = Assignment::new(offset, AssignmentKind::Multiple);
-                a.in_branch = in_branch;
-                a.shadowing_in_branch = shadowing_in_branch;
-                a.branch_id = branch_id;
-                a.branch_path = branch_path.clone();
-                a.sequence = seq;
-                a.rhs_references_var = rhs_refs_var;
-                self.table.assign_to_variable(&name, a);
-            } else {
-                self.visit(&target);
-            }
+            self.assign_multi_target(
+                &target,
+                &rhs_refs,
+                in_branch,
+                shadowing_in_branch,
+                branch_id,
+                branch_path.clone(),
+                seq,
+            );
         }
         if let Some(rest) = node.rest() {
             if let Some(splat) = rest.as_splat_node() {
@@ -1134,27 +1194,15 @@ impl<'pr> Visit<'pr> for Engine<'_> {
             }
         }
         for target in node.rights().iter() {
-            if let Some(t) = target.as_local_variable_target_node() {
-                let name = t.name().as_slice().to_vec();
-                let offset = t.location().start_offset();
-                if !self.table.variable_exists(&name) {
-                    self.declare_variable(name.clone(), offset, DeclarationKind::Assignment);
-                }
-                let rhs_refs_var = rhs_refs
-                    .iter()
-                    .find(|(n, _)| n == &name)
-                    .is_some_and(|(_, r)| *r);
-                let mut a = Assignment::new(offset, AssignmentKind::Multiple);
-                a.in_branch = in_branch;
-                a.shadowing_in_branch = shadowing_in_branch;
-                a.branch_id = branch_id;
-                a.branch_path = branch_path.clone();
-                a.sequence = seq;
-                a.rhs_references_var = rhs_refs_var;
-                self.table.assign_to_variable(&name, a);
-            } else {
-                self.visit(&target);
-            }
+            self.assign_multi_target(
+                &target,
+                &rhs_refs,
+                in_branch,
+                shadowing_in_branch,
+                branch_id,
+                branch_path.clone(),
+                seq,
+            );
         }
     }
 
@@ -1966,6 +2014,32 @@ fn collect_modifier_conditional_child_offsets(
 
 /// Check if a predicate expression contains a local variable write.
 /// Used to detect modifier-if patterns like `puts a if (a = 123)`.
+/// Recursively collect local-variable target names inside (potentially nested)
+/// multi-write targets like `(a, b), c = []`.
+fn collect_multi_target_lvar_names(target: &ruby_prism::Node<'_>, out: &mut Vec<Vec<u8>>) {
+    if let Some(t) = target.as_local_variable_target_node() {
+        out.push(t.name().as_slice().to_vec());
+        return;
+    }
+    if let Some(mt) = target.as_multi_target_node() {
+        for inner in mt.lefts().iter() {
+            collect_multi_target_lvar_names(&inner, out);
+        }
+        if let Some(rest) = mt.rest() {
+            if let Some(splat) = rest.as_splat_node() {
+                if let Some(expr) = splat.expression() {
+                    if let Some(t) = expr.as_local_variable_target_node() {
+                        out.push(t.name().as_slice().to_vec());
+                    }
+                }
+            }
+        }
+        for inner in mt.rights().iter() {
+            collect_multi_target_lvar_names(&inner, out);
+        }
+    }
+}
+
 fn predicate_has_lvar_write(node: &ruby_prism::Node<'_>) -> bool {
     struct LvarWriteDetector {
         found: bool,
@@ -3062,28 +3136,20 @@ end
         );
     }
 
-    // ── Nested multi-write should NOT create extra assignments ────────
+    // ── Nested multi-write tracks every target ────────────────────────
 
     #[test]
-    fn test_nested_multi_write_no_extra_assignments() {
-        // `a, (b, c) = 1, [2, 3]` — nested multi-write targets b and c should
-        // NOT be tracked by the VF engine (matching RuboCop behavior). Only
-        // top-level target 'a' should have an assignment.
+    fn test_nested_multi_write_tracks_inner_targets() {
+        // `a, (b, c) = 1, [2, 3]` — inner targets `b` and `c` are tracked
+        // (matching RuboCop, which flags `Useless assignment to variable - b`
+        // when `b` is not referenced afterwards).
         let scopes = run_engine("a, (b, c) = 1, [2, 3]\nputs a\n");
         let top = &scopes[0];
-        assert!(
-            top.vars.contains_key("a"),
-            "top-level target 'a' should be tracked"
-        );
+        assert!(top.vars.contains_key("a"));
         assert_eq!(top.vars["a"].num_assignments, 1);
-        // Nested targets should NOT be tracked (no generic handler to catch them)
-        assert!(
-            !top.vars.contains_key("b"),
-            "nested multi-write target 'b' should not be tracked"
-        );
-        assert!(
-            !top.vars.contains_key("c"),
-            "nested multi-write target 'c' should not be tracked"
-        );
+        assert!(top.vars.contains_key("b"));
+        assert_eq!(top.vars["b"].num_assignments, 1);
+        assert!(top.vars.contains_key("c"));
+        assert_eq!(top.vars["c"].num_assignments, 1);
     }
 }

--- a/src/cop/variable_force/engine.rs
+++ b/src/cop/variable_force/engine.rs
@@ -1532,33 +1532,22 @@ impl<'pr> Visit<'pr> for Engine<'_> {
 
             self.visit(&node.predicate());
         } else {
-            // Pre-condition loop (while...end): visit condition first, then body.
+            // Pre-condition loop (while...end and modifier `body while cond`):
+            // visit condition first, then body. Liveness for modifier-form
+            // `body while (a = expr)` is tracked via the
+            // `in_modifier_conditional` flag rather than a dedicated branch
+            // context (matches RuboCop's `Variable#in_modifier_conditional?`).
             let pred_has_write = predicate_has_lvar_write(&node.predicate());
-            let is_modifier = node.do_keyword_loc().is_none() && node.closing_loc().is_none();
-            if pred_has_write && is_modifier {
+            if pred_has_write {
                 self.branch_depth += 1;
-                self.push_branch_with_flags(
-                    parent_id,
-                    0,
-                    true,
-                    is_modifier,
-                    false,
-                    false,
-                    false,
-                    false,
-                );
             }
             self.visit(&node.predicate());
-            if pred_has_write && is_modifier {
-                self.pop_branch();
+            if pred_has_write {
                 self.branch_depth -= 1;
             }
 
-            let body_child = if pred_has_write && is_modifier { 1 } else { 0 };
             self.branch_depth += 1;
-            self.push_branch_with_flags(
-                parent_id, body_child, false, false, false, false, false, false,
-            );
+            self.push_branch_with_flags(parent_id, 0, false, false, false, false, false, false);
             if let Some(stmts) = node.statements() {
                 for stmt in stmts.body().iter() {
                     self.visit(&stmt);
@@ -1594,33 +1583,22 @@ impl<'pr> Visit<'pr> for Engine<'_> {
 
             self.visit(&node.predicate());
         } else {
-            // Pre-condition loop (until...end): visit condition first, then body.
+            // Pre-condition loop (until...end and modifier `body until cond`):
+            // visit condition first, then body. Liveness for modifier-form
+            // `body until (a = expr)` is tracked via the
+            // `in_modifier_conditional` flag rather than a dedicated branch
+            // context (matches RuboCop's `Variable#in_modifier_conditional?`).
             let pred_has_write = predicate_has_lvar_write(&node.predicate());
-            let is_modifier = node.do_keyword_loc().is_none() && node.closing_loc().is_none();
-            if pred_has_write && is_modifier {
+            if pred_has_write {
                 self.branch_depth += 1;
-                self.push_branch_with_flags(
-                    parent_id,
-                    0,
-                    true,
-                    is_modifier,
-                    false,
-                    false,
-                    false,
-                    false,
-                );
             }
             self.visit(&node.predicate());
-            if pred_has_write && is_modifier {
-                self.pop_branch();
+            if pred_has_write {
                 self.branch_depth -= 1;
             }
 
-            let body_child = if pred_has_write && is_modifier { 1 } else { 0 };
             self.branch_depth += 1;
-            self.push_branch_with_flags(
-                parent_id, body_child, false, false, false, false, false, false,
-            );
+            self.push_branch_with_flags(parent_id, 0, false, false, false, false, false, false);
             if let Some(stmts) = node.statements() {
                 for stmt in stmts.body().iter() {
                     self.visit(&stmt);

--- a/src/cop/variable_force/engine.rs
+++ b/src/cop/variable_force/engine.rs
@@ -1318,42 +1318,27 @@ impl<'pr> Visit<'pr> for Engine<'_> {
     fn visit_if_node(&mut self, node: &ruby_prism::IfNode<'pr>) {
         let location = node.location();
         let parent_id = Self::branch_parent_id(&location);
-        let is_modifier = node.end_keyword_loc().is_none() && node.if_keyword_loc().is_some();
+        let _is_modifier = node.end_keyword_loc().is_none() && node.if_keyword_loc().is_some();
 
         // RuboCop's ShadowedArgument treats any assignment under an if/unless
         // predicate as conditional, even though the predicate itself always
-        // executes. For statement form, bump branch_depth without pushing a
-        // branch context so the assignment stays visible to later reads like
-        // a `case` predicate write. Modifier form still needs a real
-        // predicate context so the left-hand body can see an earlier
-        // assignment (`puts a if (a = 123)`).
+        // executes. Bump branch_depth without pushing a branch context so the
+        // ShadowedArgument cop sees these as in-branch writes, matching
+        // RuboCop. Liveness for modifier-form patterns like
+        // `puts a if (a = 123)` is handled separately via the
+        // `in_modifier_conditional` flag on assignments whose direct parent
+        // is the modifier-if itself.
         let pred_has_write = predicate_has_lvar_write(&node.predicate());
         if pred_has_write {
             self.branch_depth += 1;
-            if is_modifier {
-                self.push_branch_with_flags(
-                    parent_id,
-                    0,
-                    true,
-                    is_modifier,
-                    false,
-                    false,
-                    false,
-                    false,
-                );
-            }
         }
         self.visit(&node.predicate());
         if pred_has_write {
-            if is_modifier {
-                self.pop_branch();
-            }
             self.branch_depth -= 1;
         }
 
-        let body_child = if pred_has_write && is_modifier { 1 } else { 0 };
         self.branch_depth += 1;
-        self.push_branch(parent_id, body_child, false);
+        self.push_branch(parent_id, 0, false);
         if let Some(stmts) = node.statements() {
             for stmt in stmts.body().iter() {
                 self.visit(&stmt);
@@ -1363,7 +1348,7 @@ impl<'pr> Visit<'pr> for Engine<'_> {
         self.branch_depth -= 1;
         if let Some(subsequent) = node.subsequent() {
             self.branch_depth += 1;
-            self.push_branch(parent_id, body_child + 1, false);
+            self.push_branch(parent_id, 1, false);
             self.visit(&subsequent);
             self.pop_branch();
             self.branch_depth -= 1;
@@ -1373,29 +1358,14 @@ impl<'pr> Visit<'pr> for Engine<'_> {
     fn visit_unless_node(&mut self, node: &ruby_prism::UnlessNode<'pr>) {
         let location = node.location();
         let parent_id = Self::branch_parent_id(&location);
-        let is_modifier = node.end_keyword_loc().is_none();
+        let _is_modifier = node.end_keyword_loc().is_none();
 
         let pred_has_write = predicate_has_lvar_write(&node.predicate());
         if pred_has_write {
             self.branch_depth += 1;
-            if is_modifier {
-                self.push_branch_with_flags(
-                    parent_id,
-                    0,
-                    true,
-                    is_modifier,
-                    false,
-                    false,
-                    false,
-                    false,
-                );
-            }
         }
         self.visit(&node.predicate());
         if pred_has_write {
-            if is_modifier {
-                self.pop_branch();
-            }
             self.branch_depth -= 1;
         }
 
@@ -1405,12 +1375,9 @@ impl<'pr> Visit<'pr> for Engine<'_> {
         // A (the unless body, as else-branch). We must match this order
         // for `find_variable` to return the same declaration_offset as
         // RuboCop's VF.
-        let body_child = if pred_has_write && is_modifier { 1 } else { 0 };
         self.branch_depth += 1;
         if let Some(else_clause) = node.else_clause() {
-            self.push_branch_with_flags(
-                parent_id, body_child, false, false, false, false, false, true,
-            );
+            self.push_branch_with_flags(parent_id, 0, false, false, false, false, false, true);
             if let Some(stmts) = else_clause.statements() {
                 for stmt in stmts.body().iter() {
                     self.visit(&stmt);
@@ -1418,7 +1385,7 @@ impl<'pr> Visit<'pr> for Engine<'_> {
             }
             self.pop_branch();
         }
-        self.push_branch(parent_id, body_child + 1, false);
+        self.push_branch(parent_id, 1, false);
         if let Some(stmts) = node.statements() {
             for stmt in stmts.body().iter() {
                 self.visit(&stmt);
@@ -1941,6 +1908,33 @@ fn collect_modifier_conditional_child_offsets(
     impl Collector {
         fn record_direct_child(&mut self, child: Option<Node<'_>>) {
             let Some(child) = child else { return };
+            // RuboCop's `in_modifier_conditional?` unwraps a `begin` parent
+            // (i.e. parenthesized expression) before checking the conditional.
+            // Mirror that here so patterns like `puts a if (a = 123)` are
+            // matched even though `(...)` introduces a `ParenthesesNode` /
+            // `BeginNode` wrapper in Prism's AST.
+            let child = if let Some(begin) = child.as_parentheses_node() {
+                if let Some(body) = begin.body() {
+                    if let Some(stmts) = body.as_statements_node() {
+                        let mut iter = stmts.body().iter();
+                        if let Some(first) = iter.next() {
+                            if iter.next().is_none() {
+                                first
+                            } else {
+                                return;
+                            }
+                        } else {
+                            return;
+                        }
+                    } else {
+                        body
+                    }
+                } else {
+                    return;
+                }
+            } else {
+                child
+            };
             if let Some(n) = child.as_local_variable_write_node() {
                 self.offsets.insert(n.location().start_offset());
             } else if let Some(n) = child.as_local_variable_operator_write_node() {
@@ -1962,6 +1956,10 @@ fn collect_modifier_conditional_child_offsets(
                         self.record_direct_child(Some(stmt));
                     }
                 }
+                // RuboCop's `in_modifier_conditional?` also matches an
+                // assignment whose direct parent is the modifier conditional
+                // itself — patterns like `puts a if (a = 123)`.
+                self.record_direct_child(Some(node.predicate()));
             }
             ruby_prism::visit_if_node(self, node);
         }
@@ -1974,6 +1972,7 @@ fn collect_modifier_conditional_child_offsets(
                         self.record_direct_child(Some(stmt));
                     }
                 }
+                self.record_direct_child(Some(node.predicate()));
             }
             ruby_prism::visit_unless_node(self, node);
         }
@@ -1988,6 +1987,7 @@ fn collect_modifier_conditional_child_offsets(
                         self.record_direct_child(Some(stmt));
                     }
                 }
+                self.record_direct_child(Some(node.predicate()));
             }
             ruby_prism::visit_while_node(self, node);
         }
@@ -2002,6 +2002,7 @@ fn collect_modifier_conditional_child_offsets(
                         self.record_direct_child(Some(stmt));
                     }
                 }
+                self.record_direct_child(Some(node.predicate()));
             }
             ruby_prism::visit_until_node(self, node);
         }

--- a/src/cop/variable_force/engine.rs
+++ b/src/cop/variable_force/engine.rs
@@ -654,7 +654,16 @@ impl<'pr> Visit<'pr> for Engine<'_> {
         r.branch_id = self.current_branch_id();
         r.branch_path = self.current_branch_path();
         self.table.reference_variable(&name, r);
+        // Mirror RuboCop's `Branch::OpAsgn(right_body)`: the RHS of an op-assign
+        // gets its own branch context so reads of other locals inside it can
+        // walk back past sibling-branch assignments to the originating
+        // initializer.
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, false, false);
         self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
         let seq = self.next_sequence();
         let mut a = Assignment::new(offset, AssignmentKind::Operator);
         a.sequence = seq;
@@ -684,7 +693,12 @@ impl<'pr> Visit<'pr> for Engine<'_> {
         r.branch_id = self.current_branch_id();
         r.branch_path = self.current_branch_path();
         self.table.reference_variable(&name, r);
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
         self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
         let seq = self.next_sequence();
         let mut a = Assignment::new(offset, AssignmentKind::LogicalOr);
         a.sequence = seq;
@@ -714,7 +728,12 @@ impl<'pr> Visit<'pr> for Engine<'_> {
         r.branch_id = self.current_branch_id();
         r.branch_path = self.current_branch_path();
         self.table.reference_variable(&name, r);
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
         self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
         let seq = self.next_sequence();
         let mut a = Assignment::new(offset, AssignmentKind::LogicalAnd);
         a.sequence = seq;
@@ -725,6 +744,270 @@ impl<'pr> Visit<'pr> for Engine<'_> {
         a.branch_path = self.current_branch_path();
         a.in_modifier_conditional = in_modifier_conditional;
         self.table.assign_to_variable(&name, a);
+    }
+
+    fn visit_call_operator_write_node(&mut self, node: &ruby_prism::CallOperatorWriteNode<'pr>) {
+        if let Some(recv) = node.receiver() {
+            self.visit(&recv);
+        }
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, false, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_call_or_write_node(&mut self, node: &ruby_prism::CallOrWriteNode<'pr>) {
+        if let Some(recv) = node.receiver() {
+            self.visit(&recv);
+        }
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_call_and_write_node(&mut self, node: &ruby_prism::CallAndWriteNode<'pr>) {
+        if let Some(recv) = node.receiver() {
+            self.visit(&recv);
+        }
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_index_operator_write_node(&mut self, node: &ruby_prism::IndexOperatorWriteNode<'pr>) {
+        if let Some(recv) = node.receiver() {
+            self.visit(&recv);
+        }
+        if let Some(args) = node.arguments() {
+            for arg in args.arguments().iter() {
+                self.visit(&arg);
+            }
+        }
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, false, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_index_or_write_node(&mut self, node: &ruby_prism::IndexOrWriteNode<'pr>) {
+        if let Some(recv) = node.receiver() {
+            self.visit(&recv);
+        }
+        if let Some(args) = node.arguments() {
+            for arg in args.arguments().iter() {
+                self.visit(&arg);
+            }
+        }
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_global_variable_operator_write_node(
+        &mut self,
+        node: &ruby_prism::GlobalVariableOperatorWriteNode<'pr>,
+    ) {
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, false, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_global_variable_or_write_node(
+        &mut self,
+        node: &ruby_prism::GlobalVariableOrWriteNode<'pr>,
+    ) {
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_global_variable_and_write_node(
+        &mut self,
+        node: &ruby_prism::GlobalVariableAndWriteNode<'pr>,
+    ) {
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_instance_variable_operator_write_node(
+        &mut self,
+        node: &ruby_prism::InstanceVariableOperatorWriteNode<'pr>,
+    ) {
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, false, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_instance_variable_or_write_node(
+        &mut self,
+        node: &ruby_prism::InstanceVariableOrWriteNode<'pr>,
+    ) {
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_instance_variable_and_write_node(
+        &mut self,
+        node: &ruby_prism::InstanceVariableAndWriteNode<'pr>,
+    ) {
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_class_variable_operator_write_node(
+        &mut self,
+        node: &ruby_prism::ClassVariableOperatorWriteNode<'pr>,
+    ) {
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, false, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_class_variable_or_write_node(
+        &mut self,
+        node: &ruby_prism::ClassVariableOrWriteNode<'pr>,
+    ) {
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_class_variable_and_write_node(
+        &mut self,
+        node: &ruby_prism::ClassVariableAndWriteNode<'pr>,
+    ) {
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_constant_operator_write_node(
+        &mut self,
+        node: &ruby_prism::ConstantOperatorWriteNode<'pr>,
+    ) {
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, false, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_constant_or_write_node(&mut self, node: &ruby_prism::ConstantOrWriteNode<'pr>) {
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_constant_and_write_node(&mut self, node: &ruby_prism::ConstantAndWriteNode<'pr>) {
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_constant_path_operator_write_node(
+        &mut self,
+        node: &ruby_prism::ConstantPathOperatorWriteNode<'pr>,
+    ) {
+        self.visit_constant_path_node(&node.target());
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, false, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_constant_path_or_write_node(
+        &mut self,
+        node: &ruby_prism::ConstantPathOrWriteNode<'pr>,
+    ) {
+        self.visit_constant_path_node(&node.target());
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_constant_path_and_write_node(
+        &mut self,
+        node: &ruby_prism::ConstantPathAndWriteNode<'pr>,
+    ) {
+        self.visit_constant_path_node(&node.target());
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
+    }
+
+    fn visit_index_and_write_node(&mut self, node: &ruby_prism::IndexAndWriteNode<'pr>) {
+        if let Some(recv) = node.receiver() {
+            self.visit(&recv);
+        }
+        if let Some(args) = node.arguments() {
+            for arg in args.arguments().iter() {
+                self.visit(&arg);
+            }
+        }
+        let parent_id = Self::branch_parent_id(&node.location());
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 1, false, false, false, false, true, false);
+        self.visit(&node.value());
+        self.pop_branch();
+        self.branch_depth -= 1;
     }
 
     fn visit_multi_write_node(&mut self, node: &ruby_prism::MultiWriteNode<'pr>) {
@@ -1506,13 +1789,21 @@ impl<'pr> Visit<'pr> for Engine<'_> {
         self.visit(&node.collection());
         let index = node.index();
         self.declare_and_assign_for_targets(&index);
+        let location = node.location();
+        let parent_id = Self::branch_parent_id(&location);
+        // Mirror RuboCop's `Branch::For` (element=0, collection=1, body=2):
+        // wrap the body in a branch context so reads of the loop's index can
+        // reach assignments living inside other for-loops in the same scope.
+        self.branch_depth += 1;
+        self.push_branch_with_flags(parent_id, 2, false, false, false, false, false, false);
         if let Some(stmts) = node.statements() {
             for stmt in stmts.body().iter() {
                 self.visit(&stmt);
             }
         }
-        let loc = node.location();
-        self.mark_loop_back_edges(loc.start_offset(), loc.end_offset());
+        self.pop_branch();
+        self.branch_depth -= 1;
+        self.mark_loop_back_edges(location.start_offset(), location.end_offset());
     }
 
     fn visit_forwarding_super_node(&mut self, node: &ruby_prism::ForwardingSuperNode<'pr>) {
@@ -1548,12 +1839,25 @@ impl<'pr> Visit<'pr> for Engine<'_> {
             let si = self.table.current_scope_index();
             let branch_id = self.current_branch_id();
             let branch_path = self.current_branch_path();
+            // Take branch_contexts out so we can pass them to reference_with_branches.
+            let contexts = std::mem::take(&mut self.table.branch_contexts);
             for var in self.table.accessible_variables_mut() {
                 let mut reference = Reference::implicit(offset, si);
-                reference.branch_id = branch_id;
-                reference.branch_path = branch_path.clone();
-                var.reference(reference);
+                // RuboCop's `Branch.of(node, scope: var.scope)` returns nil when
+                // the binding lives in an inner scope, so cross-scope references
+                // act as if they had no branch context. Emulate that here by
+                // dropping the current branch path for outer-scope variables;
+                // same-scope references keep the live branch_id/branch_path.
+                if var.scope_index == si {
+                    reference.branch_id = branch_id;
+                    reference.branch_path = branch_path.clone();
+                } else {
+                    reference.branch_id = None;
+                    reference.branch_path = Vec::new();
+                }
+                var.reference_with_branches(reference, &contexts);
             }
+            self.table.branch_contexts = contexts;
         }
         if let Some(recv) = node.receiver() {
             self.visit(&recv);

--- a/src/cop/variable_force/scope.rs
+++ b/src/cop/variable_force/scope.rs
@@ -35,8 +35,11 @@ pub enum ScopeKind {
 
 impl ScopeKind {
     /// Whether this scope can access local variables from enclosing scopes.
+    /// Matches RuboCop's `find_variable` which only walks through block-like
+    /// scopes (`block`, `numblock`, `itblock`); `def`/`defs`/class/module/
+    /// sclass all act as hard local-variable boundaries.
     pub fn is_twisted(&self) -> bool {
-        matches!(self, Self::Block | Self::Defs | Self::SingletonClass)
+        matches!(self, Self::Block)
     }
 
     /// Whether this scope creates a hard boundary that blocks access to outer

--- a/tests/fixtures/cops/lint/useless_assignment/offense.rb
+++ b/tests/fixtures/cops/lint/useless_assignment/offense.rb
@@ -218,7 +218,6 @@ exec_resp = PWN::Plugins::MSR206.exec(
 ^ Lint/UselessAssignment: Useless assignment to variable - `exec_resp`.
 
 is_found ? found += [c] : found
-           ^^^^^ Lint/UselessAssignment: Useless assignment to variable - `found`.
 
 is_found ? found += [c] : found
            ^^^^^ Lint/UselessAssignment: Useless assignment to variable - `found`.


### PR DESCRIPTION
## Summary

This PR improves the variable force engine's handling of assignment liveness tracking to better match RuboCop's behavior. It addresses several issues with how assignments are tracked in different contexts, particularly around operator assignments, nested multi-target assignments, and branch context handling.

## Key Changes

- **Operator/logical assignment branch contexts**: Added proper branch context wrapping for `+=`, `||=`, `&&=` operators and their variants (call, index, global, instance, class variables, constants). The RHS of these assignments now gets its own branch context so reads can properly walk back past sibling-branch assignments.

- **Nested multi-target tracking**: Implemented `assign_multi_target()` method to recursively handle nested parenthesized targets in multi-write assignments (e.g., `(a,), b = []`). Previously, nested targets were not tracked; now they are properly declared and assigned.

- **Multi-target name collection**: Added `collect_multi_target_lvar_names()` helper to recursively collect variable names from nested multi-target structures before visiting the RHS, enabling proper self-reference detection.

- **Modifier conditional handling**: Simplified branch context handling for modifier-form conditionals (`if`/`unless`/`while`/`until` modifiers). Removed dedicated branch contexts for modifier predicates and instead rely on the `in_modifier_conditional` flag for liveness tracking, matching RuboCop's approach.

- **For-loop branch context**: Added proper branch context wrapping for for-loop bodies to match RuboCop's `Branch::For` structure, allowing loop index reads to reach assignments in other for-loops.

- **Block capture protection**: Added `captured_protection` field to suppress force-emit pathways when assignments are only captured by blocks (not actually referenced), honoring RuboCop's `captured_by_block` behavior.

- **Retry-protected rescue refinement**: Enhanced retry-protection tracking to be begin-block scoped rather than scope-wide. Only rescue captures in the same or sibling begin blocks are protected, not those in outer containing blocks.

- **Chained assignment suppression**: Added `collect_chained_assignment_descendant_offsets()` to suppress nested assignments in chained assignment expressions, preventing false positives.

- **Cross-scope reference handling**: Fixed implicit block parameter references to drop branch context for outer-scope variables, matching RuboCop's `Branch.of(node, scope: var.scope)` behavior.

## Notable Implementation Details

- The `assign_multi_target()` method mirrors the recursive structure of multi-target nodes, handling `LocalVariableTargetNode`, nested `MultiTargetNode`, and splat expressions.
- Branch context wrapping for operator assignments uses `push_branch_with_flags()` with appropriate flags for logical operators (`is_or_assign`/`is_and_assign`).
- Modifier conditional tracking now relies on `collect_modifier_conditional_child_offsets()` which properly unwraps parenthesized expressions and checks both direct children and the predicate itself.
- Retry-protection now tracks begin block ranges to prevent over-suppression of rescue captures in unrelated outer scopes.

https://claude.ai/code/session_01MHLfdDQzHNozk3iCt3dTkV