### PR TITLE
Pin claude-code-action to commit SHA

### DIFF
--- a/.github/actions/run-agent/action.yml
+++ b/.github/actions/run-agent/action.yml
@@ -134,7 +134,7 @@ runs:
     - name: Run agent (action)
       if: steps.resolve.outputs.action == 'true'
       id: action_agent
-      uses: anthropics/claude-code-action@v1
+      uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         prompt: ${{ steps.resolve.outputs.prompt_content }}


### PR DESCRIPTION
## What

Pin `anthropics/claude-code-action` from the floating annotated tag `@v1` to the immutable commit it currently resolves to:

```
anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
```

## Why

`@v1` is a movable tag. If it were repointed (supply-chain compromise of the action, or a bad release), it would silently change the code running in our privileged agent step — which runs with `--dangerously-skip-permissions` and credentials in env. Pinning to a commit SHA removes that mutable link; the `# v1` comment keeps Dependabot able to bump it.

Motivated by the Flatt Security write-up "Poisoning Claude Code: One GitHub Issue to Break the Supply Chain". The pinned commit is the current post-patch `v1` HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)